### PR TITLE
feat: Add AI agent chat widget powered by Claude

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,5 +1,5 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
-import { Header } from "./components";
+import { Header, Agent } from "./components";
 import {
   Account,
   Messages,
@@ -53,6 +53,7 @@ function App() {
           <Route path="*" element={<PageNotFound />} />
         </Routes>
       </BrowserRouter>
+      <Agent />
     </>
   );
 }

--- a/client/src/components/agent/Agent.css
+++ b/client/src/components/agent/Agent.css
@@ -1,0 +1,359 @@
+/* =============================================
+   AI AGENT WIDGET – dark glassmorphism
+   ============================================= */
+
+/* ── Floating Action Button ───────────────── */
+.agent-fab {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  width: 58px;
+  height: 58px;
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  background: linear-gradient(135deg, #4a9eff 0%, #7c3aed 100%);
+  box-shadow: 0 4px 24px rgba(74, 158, 255, 0.45), 0 2px 8px rgba(0, 0, 0, 0.4);
+  transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+  color: #fff;
+}
+
+.agent-fab:hover {
+  transform: scale(1.08) translateY(-2px);
+  box-shadow: 0 8px 32px rgba(74, 158, 255, 0.6), 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+.agent-fab--active {
+  background: linear-gradient(135deg, #7c3aed 0%, #4a9eff 100%);
+  transform: rotate(90deg);
+}
+
+.agent-fab--active:hover {
+  transform: rotate(90deg) scale(1.08);
+}
+
+.agent-fab-badge {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  background: #f87171;
+  border: 2px solid #0a0f1e;
+  animation: agent-pulse 1.5s infinite;
+}
+
+@keyframes agent-pulse {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.3); opacity: 0.7; }
+}
+
+/* ── Chat Panel ───────────────────────────── */
+.agent-panel {
+  position: fixed;
+  bottom: calc(2rem + 58px + 1rem);
+  right: 2rem;
+  width: 360px;
+  max-height: 520px;
+  display: flex;
+  flex-direction: column;
+  border-radius: 18px;
+  overflow: hidden;
+  z-index: 999;
+
+  background: rgba(8, 12, 28, 0.88);
+  backdrop-filter: blur(28px);
+  -webkit-backdrop-filter: blur(28px);
+  border: 1px solid rgba(74, 158, 255, 0.18);
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.7), 0 0 0 1px rgba(255, 255, 255, 0.04);
+
+  opacity: 0;
+  transform: translateY(20px) scale(0.97);
+  pointer-events: none;
+  transition: opacity 0.28s ease, transform 0.28s cubic-bezier(0.34, 1.56, 0.64, 1);
+  transform-origin: bottom right;
+}
+
+.agent-panel--open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: all;
+}
+
+/* ── Panel Header ─────────────────────────── */
+.agent-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.2rem;
+  background: rgba(74, 158, 255, 0.08);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  flex-shrink: 0;
+}
+
+.agent-header-info {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.agent-header-avatar {
+  position: relative;
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #4a9eff22, #7c3aed33);
+  border: 1.5px solid rgba(74, 158, 255, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #4a9eff;
+  flex-shrink: 0;
+}
+
+.agent-status-dot {
+  position: absolute;
+  bottom: 1px;
+  right: 1px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #34d399;
+  border: 2px solid rgba(8, 12, 28, 0.9);
+}
+
+.agent-header-name {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #e5e7eb;
+  margin: 0;
+  line-height: 1.2;
+}
+
+.agent-header-sub {
+  font-size: 0.72rem;
+  color: #34d399;
+  margin: 0;
+  line-height: 1.2;
+}
+
+.agent-close-btn {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: rgba(229, 231, 235, 0.5);
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.2s, background 0.2s;
+}
+
+.agent-close-btn:hover {
+  color: #e5e7eb;
+  background: rgba(255, 255, 255, 0.07);
+}
+
+/* ── Messages Area ────────────────────────── */
+.agent-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  direction: rtl;
+  scroll-behavior: smooth;
+}
+
+.agent-messages::-webkit-scrollbar { width: 4px; }
+.agent-messages::-webkit-scrollbar-track { background: transparent; }
+.agent-messages::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 10px;
+}
+.agent-messages::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.25);
+}
+
+/* ── Message Rows ─────────────────────────── */
+.agent-message {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.5rem;
+  animation: agent-fadein 0.2s ease;
+}
+
+@keyframes agent-fadein {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.agent-message--user {
+  flex-direction: row-reverse;
+}
+
+/* ── Avatar ───────────────────────────────── */
+.agent-avatar {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #4a9eff22, #7c3aed33);
+  border: 1px solid rgba(74, 158, 255, 0.25);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #4a9eff;
+  flex-shrink: 0;
+}
+
+/* ── Bubbles ──────────────────────────────── */
+.agent-bubble {
+  max-width: 78%;
+  padding: 0.65rem 0.9rem;
+  border-radius: 16px;
+  position: relative;
+}
+
+.agent-bubble p {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.agent-bubble--bot {
+  background: rgba(30, 40, 70, 0.75);
+  border: 1px solid rgba(74, 158, 255, 0.15);
+  color: #e5e7eb;
+  border-bottom-right-radius: 4px;
+}
+
+.agent-bubble--user {
+  background: linear-gradient(135deg, #4a9eff 0%, #7c3aed 100%);
+  color: #fff;
+  border-bottom-left-radius: 4px;
+}
+
+.agent-time {
+  display: block;
+  font-size: 0.65rem;
+  opacity: 0.5;
+  margin-top: 0.3rem;
+  text-align: left;
+}
+
+.agent-bubble--user .agent-time {
+  text-align: right;
+}
+
+/* ── Typing Indicator ─────────────────────── */
+.agent-typing {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  height: 18px;
+}
+
+.agent-typing span {
+  display: block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: rgba(74, 158, 255, 0.7);
+  animation: agent-bounce 1.2s infinite ease-in-out;
+}
+
+.agent-typing span:nth-child(2) { animation-delay: 0.2s; }
+.agent-typing span:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes agent-bounce {
+  0%, 60%, 100% { transform: translateY(0); opacity: 0.5; }
+  30% { transform: translateY(-6px); opacity: 1; }
+}
+
+/* ── Input Area ───────────────────────────── */
+.agent-input-area {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(0, 0, 0, 0.25);
+  flex-shrink: 0;
+  direction: rtl;
+}
+
+.agent-input {
+  flex: 1;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  padding: 0.6rem 0.85rem;
+  color: #e5e7eb;
+  font-size: 0.875rem;
+  font-family: inherit;
+  resize: none;
+  outline: none;
+  line-height: 1.5;
+  max-height: 100px;
+  overflow-y: auto;
+  transition: border-color 0.2s, background 0.2s;
+}
+
+.agent-input::placeholder { color: rgba(229, 231, 235, 0.35); }
+
+.agent-input:focus {
+  border-color: rgba(74, 158, 255, 0.45);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.agent-input:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.agent-send-btn {
+  width: 38px;
+  height: 38px;
+  border-radius: 10px;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #4a9eff 0%, #7c3aed 100%);
+  color: #fff;
+  flex-shrink: 0;
+  transition: opacity 0.2s, transform 0.2s;
+}
+
+.agent-send-btn:hover:not(:disabled) {
+  opacity: 0.88;
+  transform: scale(1.06);
+}
+
+.agent-send-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+/* ── Responsive ───────────────────────────── */
+@media (max-width: 480px) {
+  .agent-panel {
+    right: 1rem;
+    left: 1rem;
+    width: auto;
+    bottom: calc(1.25rem + 58px + 0.75rem);
+  }
+
+  .agent-fab {
+    right: 1rem;
+    bottom: 1.25rem;
+  }
+}

--- a/client/src/components/agent/Agent.jsx
+++ b/client/src/components/agent/Agent.jsx
@@ -1,0 +1,187 @@
+import { useState, useRef, useEffect } from "react";
+import "./Agent.css";
+
+const BOT_INTRO = {
+  id: "intro",
+  role: "assistant",
+  content: "שלום! אני הסוכן החכם של Garage770 🔧\nאני יכול לעזור לך עם מידע על תורים, לקוחות, רכבים ועוד.\nכיצד אוכל לסייע לך היום?",
+  timestamp: new Date(),
+};
+
+const TypingIndicator = () => (
+  <div className="agent-message agent-message--bot">
+    <div className="agent-bubble agent-bubble--bot">
+      <span className="agent-typing">
+        <span /><span /><span />
+      </span>
+    </div>
+  </div>
+);
+
+const Message = ({ msg }) => {
+  const isBot = msg.role === "assistant";
+  const time = msg.timestamp.toLocaleTimeString("he-IL", { hour: "2-digit", minute: "2-digit" });
+  return (
+    <div className={`agent-message agent-message--${isBot ? "bot" : "user"}`}>
+      {isBot && (
+        <div className="agent-avatar">
+          <BotIcon />
+        </div>
+      )}
+      <div className={`agent-bubble agent-bubble--${isBot ? "bot" : "user"}`}>
+        <p>{msg.content}</p>
+        <span className="agent-time">{time}</span>
+      </div>
+    </div>
+  );
+};
+
+const BotIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="3" y="11" width="18" height="10" rx="2" />
+    <circle cx="12" cy="5" r="2" />
+    <path d="M12 7v4" />
+    <line x1="8" y1="16" x2="8" y2="16" strokeWidth="3" />
+    <line x1="12" y1="16" x2="12" y2="16" strokeWidth="3" />
+    <line x1="16" y1="16" x2="16" y2="16" strokeWidth="3" />
+  </svg>
+);
+
+const SendIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <line x1="22" y1="2" x2="11" y2="13" />
+    <polygon points="22 2 15 22 11 13 2 9 22 2" />
+  </svg>
+);
+
+const CloseIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+    <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+  </svg>
+);
+
+export default function Agent() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [messages, setMessages] = useState([BOT_INTRO]);
+  const [input, setInput] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasUnread, setHasUnread] = useState(false);
+  const bottomRef = useRef(null);
+  const inputRef = useRef(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, isLoading]);
+
+  useEffect(() => {
+    if (isOpen) {
+      setHasUnread(false);
+      setTimeout(() => inputRef.current?.focus(), 300);
+    }
+  }, [isOpen]);
+
+  const sendMessage = async () => {
+    const text = input.trim();
+    if (!text || isLoading) return;
+
+    const userMsg = { id: Date.now(), role: "user", content: text, timestamp: new Date() };
+    setMessages((prev) => [...prev, userMsg]);
+    setInput("");
+    setIsLoading(true);
+
+    try {
+      const res = await fetch("/api/agent/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ message: text, history: messages }),
+      });
+
+      const data = await res.json();
+      const botMsg = {
+        id: Date.now() + 1,
+        role: "assistant",
+        content: data.reply || "מצטער, לא הצלחתי לקבל תשובה.",
+        timestamp: new Date(),
+      };
+      setMessages((prev) => [...prev, botMsg]);
+      if (!isOpen) setHasUnread(true);
+    } catch {
+      setMessages((prev) => [
+        ...prev,
+        { id: Date.now() + 1, role: "assistant", content: "אירעה שגיאה. נסה שוב.", timestamp: new Date() },
+      ]);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleKey = (e) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      sendMessage();
+    }
+  };
+
+  return (
+    <>
+      {/* Chat Panel */}
+      <div className={`agent-panel ${isOpen ? "agent-panel--open" : ""}`} role="dialog" aria-label="AI Agent">
+        <div className="agent-panel-header">
+          <div className="agent-header-info">
+            <div className="agent-header-avatar">
+              <BotIcon />
+              <span className="agent-status-dot" />
+            </div>
+            <div>
+              <p className="agent-header-name">Garage770 Agent</p>
+              <p className="agent-header-sub">מוכן לסייע</p>
+            </div>
+          </div>
+          <button className="agent-close-btn" onClick={() => setIsOpen(false)} aria-label="סגור">
+            <CloseIcon />
+          </button>
+        </div>
+
+        <div className="agent-messages" aria-live="polite">
+          {messages.map((msg) => (
+            <Message key={msg.id} msg={msg} />
+          ))}
+          {isLoading && <TypingIndicator />}
+          <div ref={bottomRef} />
+        </div>
+
+        <form className="agent-input-area" onSubmit={(e) => { e.preventDefault(); sendMessage(); }}>
+          <textarea
+            ref={inputRef}
+            className="agent-input"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKey}
+            placeholder="כתוב הודעה..."
+            rows={1}
+            disabled={isLoading}
+          />
+          <button
+            type="submit"
+            className="agent-send-btn"
+            disabled={!input.trim() || isLoading}
+            aria-label="שלח"
+          >
+            <SendIcon />
+          </button>
+        </form>
+      </div>
+
+      {/* Floating Button */}
+      <button
+        className={`agent-fab ${isOpen ? "agent-fab--active" : ""}`}
+        onClick={() => setIsOpen((v) => !v)}
+        aria-label={isOpen ? "סגור סוכן" : "פתח סוכן AI"}
+      >
+        {isOpen ? <CloseIcon /> : <BotIcon />}
+        {hasUnread && !isOpen && <span className="agent-fab-badge" />}
+      </button>
+    </>
+  );
+}

--- a/client/src/components/index.js
+++ b/client/src/components/index.js
@@ -21,6 +21,8 @@ export { default as NavUser } from "./nav/NavUser";
 export { default as NavLanding } from "./nav/NavLanding";
 export { default as NavAdmin } from "./nav/NavAdmin";
 
+export { default as Agent } from "./agent/Agent";
+
 // Dashboard components
 export { 
   StatCard,

--- a/server/controllers/agent.js
+++ b/server/controllers/agent.js
@@ -1,0 +1,43 @@
+import Anthropic from "@anthropic-ai/sdk";
+
+const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+const SYSTEM_PROMPT = `אתה הסוכן החכם של Garage770 – מוסך שמנוהל באמצעות מערכת דיגיטלית.
+תפקידך לסייע לאנשי הצוות המנהלתי בשאלות לגבי:
+- ניהול תורים ועדכון סטטוס תיקונים
+- פרטי לקוחות ורכבים
+- שירותים שהגרז' מציע
+- נתונים סטטיסטיים ומגמות
+- כל שאלה אחרת הקשורה לפעילות המוסך
+
+ענה בצורה מקצועית, ידידותית ותמציתית בעברית.
+אם אינך יודע פרט ספציפי על הנתונים הנוכחיים, הסבר שאין לך גישה ישירה למסד הנתונים בזמן אמת.`;
+
+export const chat = async (req, res, next) => {
+  try {
+    const { message, history = [] } = req.body;
+
+    if (!message?.trim()) {
+      return res.status(400).json({ error: "Message is required" });
+    }
+
+    const conversationHistory = history
+      .filter((m) => m.role === "user" || m.role === "assistant")
+      .slice(-10)
+      .map((m) => ({ role: m.role, content: m.content }));
+
+    conversationHistory.push({ role: "user", content: message });
+
+    const response = await client.messages.create({
+      model: "claude-haiku-4-5-20251001",
+      max_tokens: 1024,
+      system: SYSTEM_PROMPT,
+      messages: conversationHistory,
+    });
+
+    const reply = response.content[0]?.text ?? "לא הצלחתי לייצר תשובה.";
+    res.json({ reply });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/server/index.js
+++ b/server/index.js
@@ -9,6 +9,7 @@ import reviewsRoute from "./routes/reviews.js";
 import contactsRoute from "./routes/contacts.js";
 import appointmentsRoute from "./routes/appointments.js";
 import dashboardRoute from "./routes/dashboard.js";
+import agentRoute from "./routes/agent.js";
 import cookieParser from "cookie-parser";
 import cors from "cors";
 import connectDB from "./config/db.js";
@@ -42,6 +43,7 @@ app.use("/api/reviews", reviewsRoute);
 app.use("/api/contacts", contactsRoute);
 app.use("/api/appointments", appointmentsRoute);
 app.use("/api/dashboard", dashboardRoute);
+app.use("/api/agent", agentRoute);
 
 app.use(errorHandler)
 app.listen(port, () => {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.100.1",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
@@ -20,6 +21,27 @@
       },
       "devDependencies": {
         "concurrently": "^7.6.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.100.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.100.1.tgz",
+      "integrity": "sha512-RANcEe7LpiLczkKGOwoXOTuFdPhuubS0i4xaAKOMpcqc55YO0mukgxppV7eygx3DXNjxWT6RYOLPyOy0aIAmwg==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aws-crypto/ie11-detection": {
@@ -1086,6 +1108,21 @@
         "tslib": "^2.3.1"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "18.11.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
@@ -1659,6 +1696,12 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-xml-parser": {
       "version": "4.0.11",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
@@ -1913,6 +1956,19 @@
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/jsonwebtoken": {
@@ -2542,6 +2598,16 @@
       "integrity": "sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==",
       "dev": true
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -2642,6 +2708,12 @@
       "bin": {
         "tree-kill": "cli.js"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "2.4.1",

--- a/server/package.json
+++ b/server/package.json
@@ -4,19 +4,18 @@
   "description": "",
   "main": "index.js",
   "type": "module",
-
   "scripts": {
-    "start": "node index.js",     
+    "start": "node index.js",
     "server": "nodemon index.js",
     "client": "npm start --prefix client",
     "dev": "concurrently \"npm run server\" \"npm run client\"",
     "build": "npm install"
-    
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.100.1",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",

--- a/server/routes/agent.js
+++ b/server/routes/agent.js
@@ -1,0 +1,9 @@
+import express from "express";
+import { chat } from "../controllers/agent.js";
+import { verifyToken } from "../utils/verifyToken.js";
+
+const router = express.Router();
+
+router.post("/chat", verifyToken, chat);
+
+export default router;


### PR DESCRIPTION
## Summary

- Added a floating AI chat widget (FAB button, bottom-right) visible across all pages
- Chat panel uses the existing dark glassmorphism theme with RTL Hebrew support
- Backend `/api/agent/chat` route powered by Claude Haiku, protected by `verifyToken`
- Conversation history (last 10 messages) is passed per request for context continuity
- Typing indicator, unread badge, smooth open/close animation

## Files changed

| File | Change |
|---|---|
| `client/src/components/agent/Agent.jsx` | New floating chat widget component |
| `client/src/components/agent/Agent.css` | Glassmorphism styles |
| `client/src/components/index.js` | Export `Agent` |
| `client/src/App.jsx` | Mount `<Agent />` outside router |
| `server/routes/agent.js` | POST `/api/agent/chat` route |
| `server/controllers/agent.js` | Claude Haiku integration |
| `server/index.js` | Register agent route |
| `server/package.json` | Add `@anthropic-ai/sdk` |

## Setup required

Add to server `.env`:
```
ANTHROPIC_API_KEY=sk-ant-...
```

## Test plan

- [ ] Login and open the floating chat button (bottom-right)
- [ ] Send a question in Hebrew and confirm a response arrives
- [ ] Verify the panel closes/opens with animation
- [ ] Verify unauthenticated requests to `/api/agent/chat` return 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)