### PR TITLE
fix: form-btn hover effect — border transparent for visible feedback (closes #59)

### DIFF
--- a/client/src/components/form/form.css
+++ b/client/src/components/form/form.css
@@ -144,7 +144,7 @@
   height: 45px;
   background: rgba(255, 255, 255, 0.1);
   color: white;
-  border: none;
+  border: 2px solid transparent;
   border-radius: 40px;
   font-size: 16px;
   font-weight: 600;
@@ -154,8 +154,13 @@
 }
 
 .form-btn:hover {
-  border-color: rgb(139, 120, 120);
+  border-color: rgba(255, 255, 255, 0.35);
+  background: rgba(255, 255, 255, 0.18);
   transform: translateY(-2px);
+}
+
+.form-btn:active {
+  transform: translateY(0);
 }
 
 /* Toggle Switch */


### PR DESCRIPTION
## What
Changed `.form-btn` from `border: none` to `border: 2px solid transparent` so the `:hover` state's `border-color` change is actually visible. Also added a subtle background change on hover and an `:active` press effect.

## Why
Closes #59 — the hover border change was completely invisible because there was no border to change.

## Test plan
- [ ] Open any form (login, register, appointment booking)
- [ ] Hover over the submit button — border should become faintly visible
- [ ] Click (hold) the button — should depress slightly (translateY(0))

🤖 Generated with [Claude Code](https://claude.com/claude-code)