### PR TITLE
fix: add prefers-reduced-motion media query for motion accessibility (closes #60)

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -62,6 +62,15 @@ body {
   }
 }
 
+/* Reduced motion — respect OS accessibility setting */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
 /* Print styles */
 @media print {
   body {


### PR DESCRIPTION
## What
Added a global `@media (prefers-reduced-motion: reduce)` block to `index.css` that collapses all animation and transition durations to 0.01ms for users who opt out of motion in their OS settings.

## Why
Closes #60 — `fadeInDown`, `fadeIn`, `spin`, and `translateY` hover transforms were running unconditionally, which can cause discomfort for users with vestibular disorders.

## Test plan
- [ ] Enable "Reduce motion" in OS accessibility settings (macOS: System Settings → Accessibility → Display; Windows: Settings → Ease of Access → Display)
- [ ] Reload the app — page-load animations should not play
- [ ] Hover over header logo — spin animation should be instant/absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)