### PR TITLE
fix: add skip-to-content link for keyboard navigation (closes #61)

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -36,7 +36,9 @@ function App() {
           v7_relativeSplatPath: true
         }}
       >
+        <a href="#main-content" className="skip-link">Skip to content</a>
         <Header />
+        <main id="main-content">
         <Routes>
           <Route path="/" element={<PageLanding />} />
           {PRIVATE_ROUTES.map(({ path, Component }) => (
@@ -53,6 +55,7 @@ function App() {
           <Route path="/unauthorized" element={<Unauthorized />} />
           <Route path="*" element={<PageNotFound />} />
         </Routes>
+        </main>
       </BrowserRouter>
       <Agent />
     </ErrorBoundary>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -13,6 +13,23 @@
   font-family: "Poppins", sans-serif;
 }
 
+/* Skip-to-content link for keyboard navigation (WCAG 2.4.1) */
+.skip-link {
+  position: absolute;
+  top: -100%;
+  left: 1rem;
+  background: #4a9eff;
+  color: white;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  font-weight: 600;
+  z-index: 9999;
+  text-decoration: none;
+}
+.skip-link:focus {
+  top: 1rem;
+}
+
 /* Responsive body layout */
 body {
   display: flex;


### PR DESCRIPTION
## What
- Added `<a href="#main-content" className="skip-link">Skip to content</a>` as the first DOM element inside `<BrowserRouter>`, before `<Header />`
- Wrapped `<Routes>` with `<main id="main-content">` so the skip target is always present
- Added `.skip-link` CSS to `index.css`: visually hidden off-screen, slides into view on `:focus`

## Why
Closes #61 — WCAG 2.4.1 (Bypass Blocks) requires a skip mechanism when keyboard users must navigate repeated blocks (the fixed header nav).

## Test plan
- [ ] Tab as first keypress on any page — a blue "Skip to content" button should appear in the top-left
- [ ] Pressing Enter on it should move focus past the nav into the main content area
- [ ] The link should be invisible to mouse users (no visual change when not focused)

🤖 Generated with [Claude Code](https://claude.com/claude-code)