### PR TITLE
fix: logo alt text to Garage770 brand name (closes #62)

### DIFF
--- a/client/src/components/header/Navbars.jsx
+++ b/client/src/components/header/Navbars.jsx
@@ -17,7 +17,7 @@ export default function Navbars() {
       <div className="main-header">
         <div className="logo">
           <Link to="/">
-            <img src={Logo} alt="logo for garage" className="logo" />
+            <img src={Logo} alt="Garage770" className="logo" />
           </Link>
         </div>
 


### PR DESCRIPTION
## What
Changed `alt="logo for garage"` → `alt="Garage770"` on the header logo image.

## Why
Closes #62 — screen readers announce the image's alt text; using the brand name is more meaningful and reinforces brand identity vs a generic description.

## Test plan
- [ ] Inspect the logo `<img>` element — `alt` should read `Garage770`
- [ ] Run a screen reader (NVDA/VoiceOver) and navigate to the header — logo should be announced as "Garage770"

🤖 Generated with [Claude Code](https://claude.com/claude-code)