### PR TITLE
fix: protect GET /api/services/user/:user with auth and ownership check (closes #64)

### DIFF
--- a/server/routes/services.js
+++ b/server/routes/services.js
@@ -12,8 +12,6 @@ import {
 import { verifyAdmin, verifyUser } from "../utils/verifyToken.js";
 const router = express.Router();
 
-// Public routes
-router.get("/user/:user", getServicesByUser);
 
 // Admin routes
 const adminRouter = express.Router();
@@ -27,6 +25,7 @@ adminRouter.delete("/:id", deleteService);
 // User routes
 const userRouter = express.Router();
 userRouter.use(verifyUser);
+userRouter.get("/user/:user", getServicesByUser);
 userRouter.get("/car/:car", getServicesByCar);
 userRouter.get("/:id", getService);
 

--- a/server/services/serviceService.js
+++ b/server/services/serviceService.js
@@ -1,5 +1,6 @@
 import Service from "../models/Service.js";
 import Car from "../models/Car.js";
+import { createError } from "../utils/error.js";
 /**
  * Creates a new service and associates it with a car
  * @param {Object} req - Express request object
@@ -78,6 +79,9 @@ const getServicesByCar = async (req) => {
 };
 
 const getServicesByUser = async (req) => {
+  if (req.user.id !== req.params.user && !req.user.isAdmin) {
+    throw createError(403, "Not authorized");
+  }
   const services = await Service.find({ user: req.params.user });
   return services;
 };


### PR DESCRIPTION
## What
- Moved `GET /api/services/user/:user` from public routes into `userRouter` (behind `verifyUser`)
- Added an ownership check in `getServicesByUser`: throws 403 if the authenticated user is not the owner and not an admin
- Added `createError` import to `serviceService.js`

## Why
Closes #64 — the endpoint was completely unauthenticated, allowing any anonymous caller to enumerate service history for any user ID. All other per-user data endpoints were already behind `verifyUser`.

## Test plan
- [ ] Unauthenticated request to `GET /api/services/user/<id>` → 401
- [ ] Authenticated request as a different user → 403
- [ ] Authenticated request as the owner → 200 with their services
- [ ] Admin request for any user ID → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)