### PR TITLE
fix: apply publicLimiter to /api/appointments to prevent flooding (closes #65)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -59,7 +59,7 @@ app.use("/api/services", servicesRoute);
 app.use("/api/messages", messagesRoute);
 app.use("/api/reviews", publicLimiter, reviewsRoute);
 app.use("/api/contacts", publicLimiter, contactsRoute);
-app.use("/api/appointments", appointmentsRoute);
+app.use("/api/appointments", publicLimiter, appointmentsRoute);
 app.use("/api/dashboard", dashboardRoute);
 app.use("/api/agent", agentRoute);
 


### PR DESCRIPTION
## What
Added `publicLimiter` middleware to the `/api/appointments` route — same limiter already applied to `/api/reviews` and `/api/contacts` (50 req / 15 min per IP).

## Why
Closes #65 — the public `POST /api/appointments` endpoint had no rate limiting, so a script could create thousands of fake appointments with no friction.

## Test plan
- [ ] Send > 50 requests to `POST /api/appointments` within 15 minutes from one IP → should receive 429 Too Many Requests after the 50th

🤖 Generated with [Claude Code](https://claude.com/claude-code)