### PR TITLE
fix: await connectDB before app.listen to ensure DB ready before serving requests (closes #66)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -67,8 +67,12 @@ app.use((req, res) => {
   res.status(404).json({ message: "Route not found" });
 });
 
-app.use(errorHandler)
-app.listen(port, () => {
-  connectDB();
-  console.log("connected to backend!");
-});
+app.use(errorHandler);
+
+async function start() {
+  await connectDB();
+  app.listen(port, () => {
+    console.log("connected to backend!");
+  });
+}
+start();


### PR DESCRIPTION
## What
Wrapped `connectDB` + `app.listen` in an `async start()` function and awaited the DB connection before binding the port. `connectDB` was already `async` — it just wasn't being awaited.

## Why
Closes #66 — the server was starting to accept HTTP connections before MongoDB was connected. Any request arriving during the startup window would fail with an unhandled Mongoose error.

## Test plan
- [ ] Start the server with a slow / unreliable DB connection — the HTTP port should only open after the "connected to mongoDB!" log line
- [ ] Normal startup: same behavior as before, no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)