### PR TITLE
fix: require currentPassword verification before allowing password change (closes #67)

### DIFF
--- a/server/services/userService.js
+++ b/server/services/userService.js
@@ -22,9 +22,12 @@ const updateUser = async (req) => {
   // Process phone number if provided
   const newPhone = phone ? templatePhone(phone) : user.phone;
 
-  // Process password: only hash if a new (different) password is provided
+  // Process password: require current password before allowing a change
   let updatedPassword = user.password;
   if (password) {
+    if (!req.body.currentPassword) throw createError(400, "Current password is required to set a new password");
+    const isCurrentValid = await bcrypt.compare(req.body.currentPassword, user.password);
+    if (!isCurrentValid) throw createError(401, "Current password is incorrect");
     const isMatchingPassword = await bcrypt.compare(password, user.password);
     if (!isMatchingPassword) {
       const salt = await bcrypt.genSalt(10);


### PR DESCRIPTION
## What
Added a `currentPassword` check before the password update in `updateUser`:
1. If `password` is in the request body, `currentPassword` must also be present (400 if missing)
2. `currentPassword` is verified against the stored bcrypt hash (401 if incorrect)
3. Only then is the new password hashed and saved

## Why
Closes #67 — a stolen JWT was enough to silently change an account's password and permanently lock out the real owner. Requiring proof of the current password blocks this attack.

## Test plan
- [ ] `PUT /api/users/:id` with `{ password: 'new' }` but no `currentPassword` → 400
- [ ] `PUT /api/users/:id` with `{ password: 'new', currentPassword: 'wrong' }` → 401
- [ ] `PUT /api/users/:id` with `{ password: 'new', currentPassword: 'correct' }` → 200, password updated
- [ ] Update other fields (username, email) without `password` → still works, no currentPassword required

🤖 Generated with [Claude Code](https://claude.com/claude-code)