### PR TITLE
fix: add indexes on date, status, user fields in Appointment model (closes #68)

### DIFF
--- a/server/models/Appointment.js
+++ b/server/models/Appointment.js
@@ -42,4 +42,8 @@ const AppointmentSchema = new Schema({
   },
 });
 
+AppointmentSchema.index({ date: 1 });
+AppointmentSchema.index({ status: 1 });
+AppointmentSchema.index({ user: 1 });
+
 export default mongoose.model("Appointment", AppointmentSchema);


### PR DESCRIPTION
## What
Added three `AppointmentSchema.index()` declarations to `server/models/Appointment.js`:
- `{ date: 1 }` — used by `getAppointmentsByDateRange`
- `{ status: 1 }` — used by `getAppointmentsByStatus`
- `{ user: 1 }` — used by user-scoped appointment lookups

## Why
Closes #68 — both query paths were full collection scans. MongoDB will build these indexes on next startup via `autoIndex` (default true in development) and they can be built explicitly in production with `Appointment.syncIndexes()`.

## Test plan
- [ ] After restart, run `db.appointments.getIndexes()` in Mongo shell — should show 4 indexes (default `_id` + 3 new ones)
- [ ] No regression in appointment CRUD operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)