### PR TITLE
fix: add default limit and optional pagination to all list endpoints (closes #39)

### DIFF
--- a/server/services/carService.js
+++ b/server/services/carService.js
@@ -56,8 +56,10 @@ const getCar = async (req) => {
   return car;
 };
 
-const getCars = async () => {
-  const cars = await Car.find().populate("owner");
+const getCars = async (req) => {
+  const limit = Math.min(parseInt(req.query.limit) || 500, 500);
+  const page = Math.max(parseInt(req.query.page) || 1, 1);
+  const cars = await Car.find().populate("owner").skip((page - 1) * limit).limit(limit);
   return cars;
 };
 
@@ -66,12 +68,16 @@ const getCarsByType = async (req) => {
   if (!ALLOWED_CAR_POPULATE_FIELDS.includes(type)) {
     throw createError(400, `Invalid populate field. Allowed: ${ALLOWED_CAR_POPULATE_FIELDS.join(', ')}`);
   }
-  const cars = await Car.find().populate(type);
+  const limit = Math.min(parseInt(req.query.limit) || 500, 500);
+  const page = Math.max(parseInt(req.query.page) || 1, 1);
+  const cars = await Car.find().populate(type).skip((page - 1) * limit).limit(limit);
   return cars;
 };
 
-const getCarsWithService = async () => {
-  const cars = await Car.find().populate("services");
+const getCarsWithService = async (req) => {
+  const limit = Math.min(parseInt(req.query.limit) || 500, 500);
+  const page = Math.max(parseInt(req.query.page) || 1, 1);
+  const cars = await Car.find().populate("services").skip((page - 1) * limit).limit(limit);
   return cars;
 };
 

--- a/server/services/contactService.js
+++ b/server/services/contactService.js
@@ -12,8 +12,10 @@ const createContact = async (req) => {
   return savedContact;
 };
 
-const getContacts = async () => {
-  const contacts = await Contact.find();
+const getContacts = async (req) => {
+  const limit = Math.min(parseInt(req.query.limit) || 500, 500);
+  const page = Math.max(parseInt(req.query.page) || 1, 1);
+  const contacts = await Contact.find().skip((page - 1) * limit).limit(limit);
   return contacts;
 };
 

--- a/server/services/messageService.js
+++ b/server/services/messageService.js
@@ -68,8 +68,10 @@ const getMessageByUser = async (req) => {
   return messagesTo.concat(messagesFrom);
 };
 
-const getMessages = async () => {
-  const messages = await Message.find();
+const getMessages = async (req) => {
+  const limit = Math.min(parseInt(req.query.limit) || 500, 500);
+  const page = Math.max(parseInt(req.query.page) || 1, 1);
+  const messages = await Message.find().skip((page - 1) * limit).limit(limit);
   return messages;
 };
 

--- a/server/services/reviewService.js
+++ b/server/services/reviewService.js
@@ -6,8 +6,10 @@ const createReview = async (req) => {
   return savedReview;
 };
 
-const getReviews = async () => {
-  const reviews = await Review.find();
+const getReviews = async (req) => {
+  const limit = Math.min(parseInt(req.query.limit) || 500, 500);
+  const page = Math.max(parseInt(req.query.page) || 1, 1);
+  const reviews = await Review.find().skip((page - 1) * limit).limit(limit);
   return reviews;
 };
 

--- a/server/services/serviceService.js
+++ b/server/services/serviceService.js
@@ -62,14 +62,18 @@ const getService = async (req) => {
   return service;
 };
 
-const getServices = async () => {
-  const services = await Service.find().populate("car");
+const getServices = async (req) => {
+  const limit = Math.min(parseInt(req.query.limit) || 500, 500);
+  const page = Math.max(parseInt(req.query.page) || 1, 1);
+  const services = await Service.find().populate("car").skip((page - 1) * limit).limit(limit);
   return services;
 };
 
 const getServicesByType = async (req) => {
   const type = req.query.populate;
-  const services = await Service.find().populate(type);
+  const limit = Math.min(parseInt(req.query.limit) || 500, 500);
+  const page = Math.max(parseInt(req.query.page) || 1, 1);
+  const services = await Service.find().populate(type).skip((page - 1) * limit).limit(limit);
   return services;
 };
 

--- a/server/services/userService.js
+++ b/server/services/userService.js
@@ -64,8 +64,10 @@ const getUser = async (req) => {
   return user;
 };
 
-const getUsers = async () => {
-  const users = await User.find().select("-password");
+const getUsers = async (req) => {
+  const limit = Math.min(parseInt(req.query.limit) || 500, 500);
+  const page = Math.max(parseInt(req.query.page) || 1, 1);
+  const users = await User.find().select("-password").skip((page - 1) * limit).limit(limit);
   return users;
 };
 
@@ -74,7 +76,9 @@ const getUsersByType = async (req) => {
   if (!ALLOWED_POPULATE_FIELDS.includes(type)) {
     throw createError(400, `Invalid populate field. Allowed: ${ALLOWED_POPULATE_FIELDS.join(', ')}`);
   }
-  const users = await User.find().populate(type);
+  const limit = Math.min(parseInt(req.query.limit) || 500, 500);
+  const page = Math.max(parseInt(req.query.page) || 1, 1);
+  const users = await User.find().populate(type).skip((page - 1) * limit).limit(limit);
   return users;
 };
 


### PR DESCRIPTION
## What
Added `?page=N&limit=N` support (default: `limit=500, page=1`) to all 6 admin list endpoints:
`getUsers`, `getUsersByType`, `getCars`, `getCarsByType`, `getCarsWithService`, `getServices`, `getServicesByType`, `getMessages`, `getContacts`, `getReviews`.

The response format stays as an array — no breaking change to existing frontend code.

## Why
Closes #39 — all list endpoints were unbounded `find()` full-collection scans. The `createHandler` factory already passes `req` to every service function, so adding `req` as a parameter and reading `req.query.limit/page` was zero-config.

## Notes
- Max limit capped at 500 (prevents clients from bypassing the guard)
- Response format unchanged — full pagination UI (with prev/next controls) is a follow-up

## Test plan
- [ ] `GET /api/users` → returns up to 500 users (same as before for small datasets)
- [ ] `GET /api/cars?limit=10&page=2` → returns cars 11–20
- [ ] `GET /api/services?limit=abc` → falls back to limit=500 (NaN → default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)