### PR TITLE
fix: allowlist fields in updateService to prevent arbitrary field injection (closes #40)

### DIFF
--- a/server/services/serviceService.js
+++ b/server/services/serviceService.js
@@ -1,6 +1,8 @@
 import Service from "../models/Service.js";
 import Car from "../models/Car.js";
 import { createError } from "../utils/error.js";
+
+const ALLOWED_SERVICE_UPDATE_FIELDS = ['title', 'description', 'price', 'paid', 'status'];
 /**
  * Creates a new service and associates it with a car
  * @param {Object} req - Express request object
@@ -43,11 +45,12 @@ const createService = async (req) => {
 };
 
 const updateService = async (req) => {
+  const safeBody = Object.fromEntries(
+    Object.entries(req.body).filter(([k]) => ALLOWED_SERVICE_UPDATE_FIELDS.includes(k))
+  );
   const updatedService = await Service.findByIdAndUpdate(
     req.params.id,
-    {
-      $set: req.body,
-    },
+    { $set: safeBody },
     { new: true }
   );
   return updatedService;


### PR DESCRIPTION
## What
Added `ALLOWED_SERVICE_UPDATE_FIELDS = ['title', 'description', 'price', 'paid', 'status']` and filtered `req.body` through it before passing to `$set` — identical pattern already used in `userService.updateUser` and `carService.updateCar`.

## Why
Closes #40 — `$set: req.body` directly allowed any caller with admin access to overwrite structural fields like `car` (ownership reassignment) without restriction.

## Test plan
- [ ] `PUT /api/services/:id` with `{ title: 'new' }` → only `title` updated
- [ ] `PUT /api/services/:id` with `{ car: 'other-id', title: 'new' }` → only `title` updated, `car` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)