### PR TITLE
fix: rate-limit messages and prevent sender identity forgery (closes #41)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -56,7 +56,7 @@ app.use("/api/auth", authLimiter, authRoute);
 app.use("/api/users", usersRoute);
 app.use("/api/cars", carsRoute);
 app.use("/api/services", servicesRoute);
-app.use("/api/messages", messagesRoute);
+app.use("/api/messages", publicLimiter, messagesRoute);
 app.use("/api/reviews", publicLimiter, reviewsRoute);
 app.use("/api/contacts", publicLimiter, contactsRoute);
 app.use("/api/appointments", publicLimiter, appointmentsRoute);

--- a/server/services/messageService.js
+++ b/server/services/messageService.js
@@ -17,19 +17,15 @@ const createMessage = async (req) => {
   });
   return savedMessage;
 };
+const ALLOWED_PUBLIC_MESSAGE_FIELDS = ['content', 'subject'];
+
 const createMessageToAdmin = async (req) => {
   const to = req.params.to;
-  const { from } = req.body;
-  const newMessage = new Message({
-    ...req.body,
-    to,
-  });
+  const safeBody = Object.fromEntries(
+    Object.entries(req.body).filter(([k]) => ALLOWED_PUBLIC_MESSAGE_FIELDS.includes(k))
+  );
+  const newMessage = new Message({ ...safeBody, to, from: null });
   const savedMessage = await newMessage.save();
-  if (from) {
-    await User.findByIdAndUpdate(from, {
-      $push: { messages: [savedMessage._id] },
-    });
-  }
   await User.findByIdAndUpdate(to, {
     $push: { messages: [savedMessage._id] },
   });


### PR DESCRIPTION
## What
Two changes:
1. Applied `publicLimiter` to all `/api/messages` routes (50 req / 15 min per IP) in `index.js`
2. In `createMessageToAdmin`: stripped all fields except `content` and `subject` from `req.body`, forced `from: null` — anonymous public messages cannot forge a sender ID

## Why
Closes #41 — the endpoint was unauthenticated with no rate limit, and `from` was taken from `req.body` allowing identity forgery. The authenticated `POST /:from/:to` route (behind `verifyToken`) remains unchanged for logged-in users.

## Test plan
- [ ] `POST /api/messages/to/:adminId` with `{ from: 'fake-id', content: 'hello' }` → message saved with `from: null`, fake ID ignored
- [ ] > 50 requests/15 min → 429
- [ ] Authenticated `POST /api/messages/:from/:to` (via token) still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)