### PR TITLE
fix: validate populate param in getServicesByType against allowlist (closes #43)

### DIFF
--- a/server/services/serviceService.js
+++ b/server/services/serviceService.js
@@ -1,6 +1,8 @@
 import Service from "../models/Service.js";
 import Car from "../models/Car.js";
 import { createError } from "../utils/error.js";
+
+const ALLOWED_SERVICE_POPULATE_FIELDS = ['car'];
 /**
  * Creates a new service and associates it with a car
  * @param {Object} req - Express request object
@@ -69,6 +71,9 @@ const getServices = async () => {
 
 const getServicesByType = async (req) => {
   const type = req.query.populate;
+  if (!ALLOWED_SERVICE_POPULATE_FIELDS.includes(type)) {
+    throw createError(400, `Invalid populate field. Allowed: ${ALLOWED_SERVICE_POPULATE_FIELDS.join(', ')}`);
+  }
   const services = await Service.find().populate(type);
   return services;
 };


### PR DESCRIPTION
## What
Added `ALLOWED_SERVICE_POPULATE_FIELDS = ['car']` and a 400 guard in `getServicesByType` — identical pattern to `getUsersByType` and `getCarsByType`.

## Why
Closes #43 — raw `req.query.populate` was passed directly to Mongoose's `.populate()` with no validation, allowing arbitrary field names.

## Test plan
- [ ] `GET /api/services/populate?populate=car` → works as before
- [ ] `GET /api/services/populate?populate=__proto__` → 400 "Invalid populate field"

🤖 Generated with [Claude Code](https://claude.com/claude-code)