### PR TITLE
fix: consolidate ADMIN_ID to single source in apiEndpoints.js (closes #44)

### DIFF
--- a/client/src/features/user/userService.js
+++ b/client/src/features/user/userService.js
@@ -1,14 +1,14 @@
 import axios from "../../axiosConfig.js";
 import { getUserId } from "../../utils.js";
+import { ADMIN_ID } from "../../api/apiEndpoints.js";
 
 const API_URL_CAR = "/cars";
 const API_URL_SERVICES = "/services";
 const API_URL_MESSAGES = "/messages";
-const ADMIN = "63e14deca4340e45d23f20b2";
 
 const createReqService = async (dataMessage) => {
   const { data } = await axios.post(
-    `${API_URL_MESSAGES}/to/${ADMIN}`,
+    `${API_URL_MESSAGES}/to/${ADMIN_ID}`,
     dataMessage
   );
 

--- a/client/src/utils.js
+++ b/client/src/utils.js
@@ -13,6 +13,3 @@ export * from "./api/index.js";
 
 // Export date utilities
 export { getMomentFromUpdatedAt, formatDate, getRelativeTime } from "./utils/dateUtils.js";
-
-// Legacy constant (still exported for compatibility)
-export const ADMIN = "63e14deca4340e45d23f20b2";


### PR DESCRIPTION
## What
- `client/src/features/user/userService.js`: removed local `ADMIN` constant, imports `ADMIN_ID` from `apiEndpoints.js` instead
- `client/src/utils.js`: removed the duplicate `export const ADMIN` — it was never imported by any other file

## Why
Closes #44 — the hardcoded ID `"63e14deca4340e45d23f20b2"` existed in 3 places. Now it lives only in `apiEndpoints.js` and every consumer imports from there.

## Test plan
- [ ] User can still send a service request message to admin
- [ ] No import errors in the browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)