### PR TITLE
fix: show error message on contact form submission failure (closes #46)

### DIFF
--- a/client/src/components/landing/contact/NewContact.jsx
+++ b/client/src/components/landing/contact/NewContact.jsx
@@ -17,6 +17,7 @@ const FIELD_ROWS = [
 export default function NewContact() {
   const [formData, setFormData] = useState({});
   const [isSubmitted, setIsSubmitted] = useState(false);
+  const [submitError, setSubmitError] = useState(null);
 
   const handleChange = (e) => {
     const { name, value, checked, type } = e.target;
@@ -28,14 +29,14 @@ export default function NewContact() {
 
   const onSubmit = async (e) => {
     e.preventDefault();
+    setSubmitError(null);
     try {
       await createContact(formData);
       setIsSubmitted(true);
-      setFormData({}); // Reset form
-      // Reset form fields
+      setFormData({});
       e.target.reset();
     } catch {
-      // submission failed silently - could add user-facing error state here
+      setSubmitError("Something went wrong. Please try again.");
     }
   };
 
@@ -59,6 +60,7 @@ export default function NewContact() {
         </div>
         <h4>Type your message here...</h4>
         <textarea name="message" required onChange={handleChange}></textarea>
+        {submitError && <p className="error">{submitError}</p>}
         <div className="button-container">
           <button type="submit">Send</button>
         </div>


### PR DESCRIPTION
## What
- Added `submitError` state to `NewContact.jsx`
- Set it in the `catch` block: "Something went wrong. Please try again."
- Clear it at the start of each submission attempt
- Render it as `<p className="error">` above the submit button (uses existing `.error` CSS class)
- Form data is preserved on failure so the user doesn't lose their input

## Why
Closes #46 — the empty `catch` block silently discarded errors. Users had no way to know if their message failed to send.

## Test plan
- [ ] Submit form with network offline → error message appears, form stays filled
- [ ] Submit valid form → success screen shown as before
- [ ] Submit, get error, fix and resubmit → error clears on next attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)