### PR TITLE
fix: replace double find queries with single $or in getMessageByUser (closes #47)

### DIFF
--- a/server/services/messageService.js
+++ b/server/services/messageService.js
@@ -59,13 +59,10 @@ const getMessage = async (req) => {
 };
 
 const getMessageByUser = async (req) => {
-  const messagesTo = await Message.find({ to: req.params.id })
-    .populate("to")
-    .populate("from");
-  const messagesFrom = await Message.find({ from: req.params.id })
-    .populate("from")
-    .populate("to");
-  return messagesTo.concat(messagesFrom);
+  const messages = await Message.find({
+    $or: [{ to: req.params.id }, { from: req.params.id }],
+  }).populate("to").populate("from");
+  return messages;
 };
 
 const getMessages = async () => {


### PR DESCRIPTION
## What
Merged two sequential `Message.find()` calls (one for `to`, one for `from`) into a single query using MongoDB's `$or` operator.

## Why
Closes #47 — two round-trips were needed to assemble what is logically a single result set. A `$or` query does it in one trip, with the same `.populate()` chain.

## Test plan
- [ ] `GET /api/messages/user/:id` returns all messages where user is sender or recipient
- [ ] No duplicate messages in the response
- [ ] Same result set as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)