### PR TITLE
fix: make Appointment.notes optional with empty string default (closes #48)

### DIFF
--- a/server/models/Appointment.js
+++ b/server/models/Appointment.js
@@ -29,7 +29,8 @@ const AppointmentSchema = new Schema({
   },
   notes: {
     type: String,
-    required: true,
+    required: false,
+    default: '',
   },
   status: {
     type: String,


### PR DESCRIPTION
## What
Changed `notes` field in `Appointment` schema from `required: true` to `required: false, default: ''`.

## Why
Closes #48 — `notes` is logically optional. With `required: true`, any booking without notes failed Mongoose validation before even hitting the DB.

## Test plan
- [ ] `POST /api/appointments` without `notes` field → appointment created successfully
- [ ] `POST /api/appointments` with `notes: ''` → still works
- [ ] Existing appointments with notes → unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)