### PR TITLE
fix: replace bare h1 Suspense fallback with full-height spinner (closes #50)

### DIFF
--- a/client/src/components/header/Header.jsx
+++ b/client/src/components/header/Header.jsx
@@ -10,7 +10,7 @@ const Header = () => {
       <HeaderProvider>
         <Navbars />
       </HeaderProvider>
-      <Suspense fallback={<h1>Loading..</h1>}>
+      <Suspense fallback={<div className="page-loader" aria-label="Loading" />}>
         <Outlet />
       </Suspense>
     </>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -79,6 +79,27 @@ body {
   }
 }
 
+/* Page loader — Suspense fallback during lazy route transitions */
+.page-loader {
+  width: 100%;
+  min-height: calc(100vh - var(--header-height));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.page-loader::after {
+  content: '';
+  width: 40px;
+  height: 40px;
+  border: 3px solid rgba(255, 255, 255, 0.2);
+  border-top-color: rgba(255, 255, 255, 0.8);
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+}
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
 /* Reduced motion — respect OS accessibility setting */
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {


### PR DESCRIPTION
## What
- Replaced `<h1>Loading..</h1>` in `Header.jsx` with `<div className="page-loader" aria-label="Loading" />`
- Added `.page-loader` + `@keyframes spin` to `index.css`: full viewport height, centered CSS spinner — no layout shift

## Why
Closes #50 — a bare `<h1>` inside Suspense during route transitions was visually jarring and shifted the layout. The spinner fills the expected page area and matches the glassmorphism design.

## Test plan
- [ ] Navigate between pages (especially admin routes) — spinner appears briefly during code chunk loading, then the page renders normally
- [ ] No layout shift visible during transition
- [ ] Spinner not visible to users who opt into `prefers-reduced-motion` (animation collapses via existing media query)

🤖 Generated with [Claude Code](https://claude.com/claude-code)