### PR TITLE
fix: wire formData onChange and add screen-reader labels to login form (closes #53)

### DIFF
--- a/client/src/components/login/NewLogin.jsx
+++ b/client/src/components/login/NewLogin.jsx
@@ -6,8 +6,10 @@ import { login } from "../../features/auth/authSlice";
 import { OpenModal } from "..";
 export default function NewLogin({ isOpen }) {
   const { isError, message } = useSelector((state) => state.auth);
-  const [formData, setFormData] = useState();
+  const [formData, setFormData] = useState({ username: "", password: "" });
   const dispatch = useDispatch();
+  const handleChange = (e) =>
+    setFormData((prev) => ({ ...prev, [e.target.name]: e.target.value }));
   const onSubmit = (e) => {
     e.preventDefault();
     dispatch(login(formData));
@@ -19,10 +21,26 @@ export default function NewLogin({ isOpen }) {
           <form onSubmit={onSubmit}>
             <h1>Login</h1>
             <div className="input-box">
-              <input type="text" name="username" placeholder="username" />
+              <label htmlFor="login-username" className="sr-only">Username</label>
+              <input
+                id="login-username"
+                type="text"
+                name="username"
+                placeholder="Username"
+                value={formData.username}
+                onChange={handleChange}
+              />
             </div>
             <div className="input-box">
-              <input type="password" name="password" placeholder="password"/>
+              <label htmlFor="login-password" className="sr-only">Password</label>
+              <input
+                id="login-password"
+                type="password"
+                name="password"
+                placeholder="Password"
+                value={formData.password}
+                onChange={handleChange}
+              />
             </div>
             <div className="remember-forgot">
               <label>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -13,6 +13,19 @@
   font-family: "Poppins", sans-serif;
 }
 
+/* Screen-reader-only utility (WCAG 3.3.2) */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* Skip-to-content link for keyboard navigation (WCAG 2.4.1) */
 .skip-link {
   position: absolute;


### PR DESCRIPTION
## What
- `useState()` → `useState({ username: '', password: '' })` — initial state is now a proper object
- Added `handleChange` handler and wired it to both inputs with `value` + `onChange`
- Added visually-hidden `<label>` elements (`htmlFor` + `.sr-only`) for each input
- Added `.sr-only` utility class to `index.css` (standard WCAG pattern)

## Why
Closes #53 — `formData` was `undefined` so `dispatch(login(undefined))` would always fail silently. Inputs had no `onChange` so they were uncontrolled and never synced state. Placeholder-only inputs violate WCAG 3.3.2.

## Test plan
- [ ] Enter username and password → login request fires with correct credentials
- [ ] Screen reader announces "Username" / "Password" labels when focusing the inputs
- [ ] Placeholder text still visible when fields are empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)