### PR TITLE
fix: move showModal() into useEffect to prevent null ref crash (closes #54)

### DIFF
--- a/client/src/components/modalDialog/ModalDialog.jsx
+++ b/client/src/components/modalDialog/ModalDialog.jsx
@@ -1,15 +1,16 @@
-import { useRef } from "react";
+import { useRef, useEffect } from "react";
 
 export default function ModalDialog() {
   const dialog = useRef();
 
-  dialog.current.showModal();
+  useEffect(() => {
+    dialog.current?.showModal();
+  }, []);
 
   return (
     <dialog ref={dialog}>
       <h1>Dialog</h1>
-
-      <button>Close</button>
+      <button onClick={() => dialog.current?.close()}>Close</button>
     </dialog>
   );
 }


### PR DESCRIPTION
## What
- Added `useEffect` import
- Moved `dialog.current.showModal()` into `useEffect(() => { ... }, [])` with optional chaining (`?.`) for safety
- Added `onClick={() => dialog.current?.close()}` to the Close button

## Why
Closes #54 — calling `dialog.current.showModal()` in the component body runs before React attaches the `ref` to the DOM, causing `TypeError: Cannot read properties of null`. `useEffect` runs after the first render, when the ref is guaranteed to be populated.

## Test plan
- [ ] Any page that renders `<ModalDialog />` no longer crashes
- [ ] Dialog opens automatically on mount
- [ ] Close button dismisses the dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)