### PR TITLE
fix: restore focus-visible rings for keyboard navigation (closes #56)

### DIFF
--- a/client/src/components/form/form.css
+++ b/client/src/components/form/form.css
@@ -138,6 +138,13 @@
   background: rgba(255, 255, 255, 0.15);
 }
 
+.form-label input:focus-visible,
+.form-label textarea:focus-visible,
+.form-label select:focus-visible {
+  outline: 2px solid rgba(74, 158, 255, 0.8);
+  outline-offset: 2px;
+}
+
 /* Button Styles */
 .form-btn {
   width: 100%;

--- a/client/src/components/login/login.css
+++ b/client/src/components/login/login.css
@@ -21,7 +21,7 @@
   width: 100%;
   height: 100%;
   background: transparent;
-  outline: none;
+  outline: none; /* suppressed for mouse users; :focus-visible below restores it for keyboard */
   border: 2px solid rgba(255, 255, 255, 0.2);
   backdrop-filter: blur(20px);
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
@@ -32,6 +32,11 @@
 }
 .input-box input::placeholder {
   color: #fff;
+}
+
+.input-box input:focus-visible {
+  outline: 2px solid rgba(74, 158, 255, 0.8);
+  outline-offset: 2px;
 }
 
 .remember-forgot {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -13,6 +13,12 @@
   font-family: "Poppins", sans-serif;
 }
 
+/* Focus-visible baseline — keyboard navigation (WCAG 2.4.7) */
+:focus-visible {
+  outline: 2px solid #4a9eff;
+  outline-offset: 2px;
+}
+
 /* Screen-reader-only utility (WCAG 3.3.2) */
 .sr-only {
   position: absolute;


### PR DESCRIPTION
## What
Three changes:
1. `index.css`: added global `:focus-visible` baseline (`2px solid #4a9eff; offset 2px`) — applies to all interactive elements by default
2. `form.css`: added `.form-label input/textarea/select:focus-visible` with the same blue ring
3. `login.css`: added `.input-box input:focus-visible` with the same ring; kept `outline: none` on `:focus` (suppresses mouse ring without removing keyboard ring)

## Why
Closes #56 — bare `outline: none` removed focus indicators entirely, violating WCAG 2.4.7. `:focus-visible` shows the ring only when keyboard navigation is detected, so mouse users are unaffected.

## Test plan
- [ ] Tab through login form → blue outline appears on focused input
- [ ] Tab through contact/appointment form → same blue ring
- [ ] Click an input with mouse → no outline visible
- [ ] Tab to submit button → blue ring visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)