### PR TITLE
fix: add aria-expanded and aria-controls to mobile nav toggle (closes #57)

### DIFF
--- a/client/src/components/header/Navbars.jsx
+++ b/client/src/components/header/Navbars.jsx
@@ -25,11 +25,13 @@ export default function Navbars() {
           className="mobile-nav-toggle"
           onClick={handleOutsideClick}
           aria-label="toggle navigation"
+          aria-expanded={isNavOpen}
+          aria-controls="main-navbar"
         >
           {isNavOpen ? "×" : "☰"}
         </button>
 
-        <div className={`navbar ${isNavOpen ? "active" : ""}`}>
+        <div id="main-navbar" className={`navbar ${isNavOpen ? "active" : ""}`}>
           <Nav />
         </div>
       </div>


### PR DESCRIPTION
## What
- Added `aria-expanded={isNavOpen}` to the hamburger button — dynamically reflects open/closed state
- Added `aria-controls="main-navbar"` to link the button to the nav it controls
- Added `id="main-navbar"` to the corresponding `<div className="navbar">` element

## Why
Closes #57 — WCAG 4.1.2 (Name, Role, Value) requires interactive controls to expose their state. Without `aria-expanded`, screen readers announce the button but cannot tell users whether the menu is open or closed.

## Test plan
- [ ] On mobile viewport, activate a screen reader and focus the hamburger button — it should announce "toggle navigation, collapsed" when nav is closed and "expanded" when open
- [ ] Inspect the DOM — `aria-expanded` should toggle between `true` and `false` on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)