### PR TITLE
fix: add icon prefix to status badges to satisfy WCAG 1.4.1 (closes #58)

### DIFF
--- a/client/src/components/table/table.css
+++ b/client/src/components/table/table.css
@@ -138,11 +138,20 @@ button[name="createService"] {
 .status.done {
   background: #828fee;
 }
+.status.done::before {
+  content: "✓ ";
+}
 .status.pending {
   background: #eef681;
 }
+.status.pending::before {
+  content: "⏳ ";
+}
 .status.on-work {
   background: #7ef1ae;
+}
+.status.on-work::before {
+  content: "⚙ ";
 }
 
 .editPaid.Paid {


### PR DESCRIPTION
## What
Added `::before` pseudo-content icons to each status class:
- `.status.done::before { content: "✓ "; }`
- `.status.pending::before { content: "⏳ "; }`
- `.status.on-work::before { content: "⚙ "; }`

## Why
Closes #58 — badges were differentiated by background color alone (WCAG 1.4.1 violation). Users with color vision deficiency couldn't distinguish statuses. The icon gives a non-color distinguisher with zero JSX changes.

## Test plan
- [ ] View admin Cars/Services table — status cells show ✓, ⏳, or ⚙ before the status text
- [ ] Convert page to grayscale in browser dev tools — statuses still distinguishable by icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)