### PR TITLE
fix: use $stars field in dashboard avg rating aggregate (closes #37)

### DIFF
--- a/server/services/dashboardService.js
+++ b/server/services/dashboardService.js
@@ -111,7 +111,7 @@ const getDashboardStats = async () => {
     {
       $group: {
         _id: null,
-        averageRating: { $avg: "$rating" },
+        averageRating: { $avg: "$stars" },
         totalReviews: { $sum: 1 },
       },
     },


### PR DESCRIPTION
## What
Changed `$avg: "$rating"` → `$avg: "$stars"` in `dashboardService.js` to match the actual field name in the `Review` Mongoose schema.

## Why
Closes #37 — the `Review` schema defines the field as `stars`, not `rating`. The `$avg` aggregate on a non-existent field always returned `null`/`0`, so the dashboard average rating was always meaningless.

## Test plan
- [ ] Submit a few reviews with different star ratings
- [ ] Open the Dashboard — average rating should now show a non-zero value matching the actual reviews
- [ ] Total review count should also be accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)