### PR TITLE
fix: require auth on POST /api/reviews and allowlist fields (closes #38)

### DIFF
--- a/server/routes/reviews.js
+++ b/server/routes/reviews.js
@@ -1,11 +1,9 @@
 import express from "express";
 import { getReviews, createReview } from "../controllers/review.js";
+import { verifyToken } from "../utils/verifyToken.js";
 const router = express.Router();
 
-//GET ALL
 router.get("/", getReviews);
-
-//POST
-router.post("/", createReview);
+router.post("/", verifyToken, createReview);
 
 export default router;

--- a/server/services/reviewService.js
+++ b/server/services/reviewService.js
@@ -1,7 +1,12 @@
 import Review from "../models/Review.js";
 
+const ALLOWED_REVIEW_FIELDS = ['name', 'description', 'stars'];
+
 const createReview = async (req) => {
-  const newReview = new Review(req.body);
+  const safeBody = Object.fromEntries(
+    Object.entries(req.body).filter(([k]) => ALLOWED_REVIEW_FIELDS.includes(k))
+  );
+  const newReview = new Review(safeBody);
   const savedReview = await newReview.save();
   return savedReview;
 };


### PR DESCRIPTION
## What
Two changes:
1. `server/routes/reviews.js`: added `verifyToken` middleware to `POST /` — only authenticated users can submit reviews
2. `server/services/reviewService.js`: added `ALLOWED_REVIEW_FIELDS = ['name', 'description', 'stars']` — filters `req.body` before creating the Review document

## Why
Closes #38 — the POST endpoint was completely unauthenticated, allowing bots and anonymous actors to spam the review system. Spreading raw `req.body` into the model also allowed injection of unexpected fields.

## Test plan
- [ ] Unauthenticated `POST /api/reviews` → 401
- [ ] Authenticated `POST /api/reviews` with `{ name, description, stars }` → 201
- [ ] Authenticated `POST /api/reviews` with extra fields (e.g. `__proto__`) → saved with only allowed fields
- [ ] `GET /api/reviews` (public) → still works without auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)