### PR TITLE
fix: lazy-load all page components for route-level code splitting (closes #49)

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,20 +1,20 @@
+import { lazy } from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { Header, Agent } from "./components";
-import {
-  Account,
-  Messages,
-  PageLanding,
-  Users,
-  Cars,
-  ServicesAdmin,
-  Appointments,
-  Dashboard,
-} from "./pages";
 import PageNotFound from "./components/pageNotFound/PageNotFound";
-import MessagesOfContact from "./pages/messagesOfContact/MessagesOfContact.jsx";
 import { PrivateRoute } from "./PrivateRoute.jsx";
-import Unauthorized from "./pages/Unauthorized";
 import ErrorBoundary from "./components/ErrorBoundary.jsx";
+
+const PageLanding       = lazy(() => import("./pages/pageLanding/PageLanding"));
+const Account           = lazy(() => import("./pages/account/Account"));
+const Users             = lazy(() => import("./pages/users/Users"));
+const Cars              = lazy(() => import("./pages/cars/Cars"));
+const Messages          = lazy(() => import("./pages/messages/Messages"));
+const ServicesAdmin     = lazy(() => import("./pages/servicesAdmin/ServicesAdmin"));
+const MessagesOfContact = lazy(() => import("./pages/messagesOfContact/MessagesOfContact"));
+const Appointments      = lazy(() => import("./pages/appointments/Appointments"));
+const Dashboard         = lazy(() => import("./pages/dashboard/Dashboard"));
+const Unauthorized      = lazy(() => import("./pages/Unauthorized"));
 
 const PRIVATE_ROUTES = [
   { path: "/myCars",           Component: Account },


### PR DESCRIPTION
## What
Replaced all static `import` statements for page components with `React.lazy()` dynamic imports. The `<Suspense>` fallback already exists in `Header.jsx` (added in PR #87) and catches all lazy route loads.

10 components converted to lazy:
`PageLanding`, `Account`, `Users`, `Cars`, `Messages`, `ServicesAdmin`, `MessagesOfContact`, `Appointments`, `Dashboard`, `Unauthorized`

## Why
Closes #49 — eager imports bundled every admin page into the initial chunk, making unauthenticated visitors download the full app. With lazy loading, each page becomes its own chunk loaded only when navigated to.

## Test plan
- [ ] Open browser DevTools → Network tab → hard reload — only the initial chunk should load
- [ ] Navigate to `/` — landing page loads with spinner momentarily
- [ ] Navigate to `/dashboard` (as admin) — Dashboard chunk loads on demand
- [ ] `PageNotFound` (non-lazy) still renders without spinner for unknown routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)