### PR TITLE
fix: sort date columns numerically via Date.parse() (closes #21)

### DIFF
--- a/client/src/components/table/TableWithSort.jsx
+++ b/client/src/components/table/TableWithSort.jsx
@@ -29,8 +29,13 @@ const Table = ({ trTh, trTd }) => {
         (child) => child.props["data-label"] === sortConfig.key
       )?.props.children;
 
-      if (aValue < bValue) return sortConfig.direction === "ascending" ? -1 : 1;
-      if (aValue > bValue) return sortConfig.direction === "ascending" ? 1 : -1;
+      const aDate = Date.parse(aValue);
+      const bDate = Date.parse(bValue);
+      const aNum = isNaN(aDate) ? aValue : aDate;
+      const bNum = isNaN(bDate) ? bValue : bDate;
+
+      if (aNum < bNum) return sortConfig.direction === "ascending" ? -1 : 1;
+      if (aNum > bNum) return sortConfig.direction === "ascending" ? 1 : -1;
       return 0;
     });
   }, [sortConfig, trTd]);


### PR DESCRIPTION
## What
In `TableWithSort.jsx`, the sort comparator now tries `Date.parse(value)` on each cell value before comparing. If both values parse as valid dates (e.g. `6/2/2026`), they are compared as timestamps (numbers). Non-date columns fall back to the original string/value comparison.

## Why
Closes #21 — localized date strings like `6/2/2026` were sorted lexicographically (`"10/..."` < `"6/..."`) which gave wrong order. Numeric timestamp comparison produces correct chronological order.

## Test plan
- [ ] Sort the Date column in the Messages or Appointments table — dates should order chronologically, not alphabetically
- [ ] Sort a text column (e.g. Name) — still works as string sort

🤖 Generated with [Claude Code](https://claude.com/claude-code)