### PR TITLE
fix: re-fetch contacts after delete so list updates in real time (closes #33)

### DIFF
--- a/client/src/pages/messagesOfContact/MsgOfContactProvider.jsx
+++ b/client/src/pages/messagesOfContact/MsgOfContactProvider.jsx
@@ -21,8 +21,9 @@ export default function MsgOfContactProvider({ children }) {
     dispatch(getMessagesContact());
   }, [dispatch]);
 
-  const handleContact = (e) => {
-    handleContactActionUtil(e);
+  const handleContact = async (e) => {
+    await handleContactActionUtil(e);
+    dispatch(getMessagesContact());
   };
 
   const value = {


### PR DESCRIPTION
## What
`handleContact` in `MsgOfContactProvider` is now `async` and dispatches `getMessagesContact()` after `handleContactActionUtil` resolves. This causes the Redux store to re-fetch the contact list immediately after a successful delete.

## Why
Closes #33 — deleting a contact message called the API but never updated the store, so the deleted row stayed visible until the page was refreshed.

## Test plan
- [ ] Go to the Messages-of-Contact admin page
- [ ] Delete a contact message — the row should disappear from the table immediately without a manual refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)