### PR TITLE
fix: add confirmation dialog before deleting a service (closes #26)

### DIFF
--- a/client/src/pages/servicesAdmin/utils/serviceHandlerUtils.js
+++ b/client/src/pages/servicesAdmin/utils/serviceHandlerUtils.js
@@ -23,7 +23,9 @@ export const handleServiceAction = async (e, services, setSelectedService, modal
       modals.editPaid.handle();
       break;
     case "deleteService":
-      await serviceActions.onSubmitDeleteService(modals.manageService.handle);
+      if (window.confirm("Are you sure you want to delete this service?")) {
+        await serviceActions.onSubmitDeleteService(modals.manageService.handle);
+      }
       break;
     case "editService":
       modals.editService.handle();


### PR DESCRIPTION
## What
Added `window.confirm('Are you sure you want to delete this service?')` in `serviceHandlerUtils.js` before calling `onSubmitDeleteService`. The delete only proceeds if the user confirms.

## Why
Closes #26 — clicking the delete button immediately deleted the service with no warning. A confirmation popup prevents accidental deletions.

## Test plan
- [ ] Click "Delete" on any service → a browser confirm dialog appears
- [ ] Click Cancel → service is NOT deleted, stays in the list
- [ ] Click OK → service is deleted and removed from the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)