### PR TITLE
refactor: second DRY pass — handler utils, messageApi, appointmentSlice

### DIFF
--- a/client/src/api/services/messageApi.js
+++ b/client/src/api/services/messageApi.js
@@ -25,12 +25,9 @@ export const messageApi = {
     const response = await axios.post(`${API_URL_MESSAGES}/to/${ADMIN_ID}`, data);
     return response.data;
   },
-  
-  // Create service request (message to admin)
-  createServiceRequest: async (data) => {
-    const response = await axios.post(`${API_URL_MESSAGES}/to/${ADMIN_ID}`, data);
-    return response.data;
-  },
+
+  // Create service request — same endpoint as createToAdmin
+  createServiceRequest(data) { return messageApi.createToAdmin(data); },
   
   // Delete message
   delete: messageOps.delete,

--- a/client/src/features/appointments/appointmentSlice.js
+++ b/client/src/features/appointments/appointmentSlice.js
@@ -3,6 +3,13 @@ import { API_URL_APPOINTMENTS } from '../../api/apiEndpoints';
 import { createAsyncThunkWithErrorHandling, addAsyncThunkCases } from '../utils/asyncThunkErrorHandler';
 import axios from 'axios';
 
+const INITIAL_FETCH_STATE = {
+  isError: false,
+  isSuccess: false,
+  isLoading: false,
+  message: "",
+};
+
 // Service functions
 const appointmentService = {
   fetchAppointments: async () => {
@@ -48,22 +55,12 @@ const appointmentSlice = createSlice({
   name: 'appointments',
   initialState: {
     appointments: [],
-    fetchState: {
-      isError: false,
-      isSuccess: false,
-      isLoading: false,
-      message: "",
-    },
+    fetchState: INITIAL_FETCH_STATE,
   },
   reducers: {
     resetAppointments: (state) => {
       state.appointments = [];
-      state.fetchState = {
-        isError: false,
-        isSuccess: false,
-        isLoading: false,
-        message: "",
-      };
+      state.fetchState = INITIAL_FETCH_STATE;
     },
     clearErrors: (state) => {
       state.fetchState.isError = false;

--- a/client/src/pages/cars/utils/carHandlerUtils.js
+++ b/client/src/pages/cars/utils/carHandlerUtils.js
@@ -1,15 +1,7 @@
-/**
- * Handle car actions based on button click
- * @param {Event} e - Event object
- * @param {Array} cars - List of cars
- * @param {Function} setSelectedCar - Function to set selected car
- * @param {Object} modals - Modal handlers
- */
+import { resolveActionTarget } from "../../../utils/handlerUtils";
+
 export const handleCarAction = (e, cars, setSelectedCar, modals) => {
-  e.preventDefault();
-  const { name, value } = e.target;
-  const car = cars.find((car) => car._id === value);
-  setSelectedCar(car);
+  const name = resolveActionTarget(e, cars, setSelectedCar);
 
   switch (name) {
     case "editCar":

--- a/client/src/pages/messages/utils/messageHandlerUtils.js
+++ b/client/src/pages/messages/utils/messageHandlerUtils.js
@@ -1,15 +1,7 @@
-/**
- * Handle message actions based on button click
- * @param {Event} e - Event object
- * @param {Array} messages - List of messages
- * @param {Function} setSelectedMsg - Function to set selected message
- * @param {Object} modals - Modal handlers
- */
+import { resolveActionTarget } from "../../../utils/handlerUtils";
+
 export const handleMessageAction = (e, messages, setSelectedMsg, modals) => {
-  e.preventDefault();
-  const { name, value } = e.target;
-  const message = messages.find((message) => message._id === value);
-  setSelectedMsg(message);
+  const name = resolveActionTarget(e, messages, setSelectedMsg);
 
   switch (name) {
     case "createMessage":

--- a/client/src/pages/servicesAdmin/utils/serviceHandlerUtils.js
+++ b/client/src/pages/servicesAdmin/utils/serviceHandlerUtils.js
@@ -1,16 +1,7 @@
-/**
- * Handle service actions based on button click
- * @param {Event} e - Event object
- * @param {Array} services - List of services
- * @param {Function} setSelectedService - Function to set selected service
- * @param {Object} modals - Modal handlers
- * @param {Object} serviceActions - Service action handlers
- * @returns {Promise<void>}
- */
+import { resolveActionTarget } from "../../../utils/handlerUtils";
+
 export const handleServiceAction = async (e, services, setSelectedService, modals, serviceActions) => {
-  e.preventDefault();
-  const { name, value } = e.target;
-  setSelectedService(services.find((service) => service._id === value));
+  const name = resolveActionTarget(e, services, setSelectedService);
 
   switch (name) {
     case "manage":

--- a/client/src/pages/users/utils/userHandlerUtils.js
+++ b/client/src/pages/users/utils/userHandlerUtils.js
@@ -1,15 +1,7 @@
-/**
- * Handle user actions based on button click
- * @param {Event} e - Event object
- * @param {Array} users - List of users
- * @param {Function} setSelectedUser - Function to set selected user
- * @param {Object} modals - Modal handlers
- */
-export const handleUserAction = async (e, users, setSelectedUser, modals) => {
-  e.preventDefault();
+import { resolveActionTarget } from "../../../utils/handlerUtils";
 
-  const { value, name } = e.target;
-  setSelectedUser(users.find((user) => user._id === value));
+export const handleUserAction = (e, users, setSelectedUser, modals) => {
+  const name = resolveActionTarget(e, users, setSelectedUser);
 
   switch (name) {
     case "editUser":

--- a/client/src/utils/handlerUtils.js
+++ b/client/src/utils/handlerUtils.js
@@ -1,0 +1,17 @@
+/**
+ * Shared prefix for every table action handler:
+ * prevents default, reads the button's name + value,
+ * finds the matching item, and sets it as selected.
+ * Returns the button name so the caller can switch on it.
+ *
+ * @param {Event}    e          - Click event
+ * @param {Array}    items      - Full list of entities
+ * @param {Function} setSelected - State setter for the selected entity
+ * @returns {string} The button's name attribute
+ */
+export const resolveActionTarget = (e, items, setSelected) => {
+  e.preventDefault();
+  const { name, value } = e.target;
+  setSelected(items.find((item) => item._id === value));
+  return name;
+};


### PR DESCRIPTION
## Summary

- **`client/src/utils/handlerUtils.js` (new)** — extracted `resolveActionTarget(e, items, setSelected)`, which replaces the identical 4-line prefix (`preventDefault` + destructure + `find` by `_id` + `setSelected`) that existed verbatim in all four table-action handler utils
- **`messageApi.js`** — `createServiceRequest` and `createToAdmin` were byte-for-byte the same axios call; `createServiceRequest` now delegates to `createToAdmin`
- **`appointmentSlice.js`** — the `fetchState` object literal was duplicated inside `initialState` and again inside `resetAppointments`; extracted to `INITIAL_FETCH_STATE` constant

All existing exports and call signatures are unchanged — pure extraction.

**Net result:** 7 files changed, 1 new shared file, ~22 lines removed (41 added / 63 deleted).

## Test plan

- [ ] Client: Cars page — click Manage / Edit / Delete buttons on a car row, confirm modals open correctly
- [ ] Client: Users page — click Manage on a user row, confirm modal opens
- [ ] Client: Services (admin) page — click edit/delete service actions, confirm modals open
- [ ] Client: Messages page — click create/delete message actions, confirm modals open
- [ ] Client: send a message to admin and a service request — both should still reach the admin endpoint
- [ ] Client: create an appointment, then reset — confirm fetchState clears correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)