### PR TITLE
fix: trim whitespace from username/email/phone in register and login (closes #14)

### DIFF
--- a/server/services/authService.js
+++ b/server/services/authService.js
@@ -24,7 +24,10 @@ const buildCookieOptions = (withMaxAge = false) => {
 };
 
 const register = async (req) => {
-  const { username, phone, email, password } = req.body;
+  const username = req.body.username?.trim();
+  const email = req.body.email?.trim().toLowerCase();
+  const phone = req.body.phone?.trim();
+  const { password } = req.body;
 
   // Input validation
   if (!username || !phone || !email || !password) {
@@ -63,7 +66,8 @@ const register = async (req) => {
 };
 
 const login = async (req) => {
-  const { username, password } = req.body;
+  const username = req.body.username?.trim();
+  const { password } = req.body;
 
   if (!username || !password) {
     throw createError(400, "Username and password are required");


### PR DESCRIPTION
## What
- `register`: trims `username`, `email` (also lowercased), and `phone` from `req.body` before validation/storage
- `login`: trims `username` before lookup

## Why
Closes #14 — leading/trailing whitespace in `username` would create a distinct user from the same name without spaces, causing confusing "user not found" errors on login and allowing duplicate-looking accounts.

## Test plan
- [ ] Register with `" admin "` (spaces around) → account created as `admin`, not `" admin "`
- [ ] Login with `" admin "` → finds the user successfully
- [ ] Email `" User@EXAMPLE.com "` normalized to `user@example.com` on register

🤖 Generated with [Claude Code](https://claude.com/claude-code)