### PR TITLE
fix: add phone uniqueness check and update conflict validation (closes #1)

### DIFF
--- a/server/services/authService.js
+++ b/server/services/authService.js
@@ -31,13 +31,15 @@ const register = async (req) => {
     throw createError(400, "All fields are required");
   }
   
-  // Check if user exists
-  const userExists = await User.findOne({ username });
-  if (userExists) throw createError(400, "User already exists");
-
-  // Check if email is already in use
-  const emailExists = await User.findOne({ email });
+  // Check uniqueness of username, email, and phone
+  const [userExists, emailExists, phoneExists] = await Promise.all([
+    User.findOne({ username }),
+    User.findOne({ email }),
+    User.findOne({ phone: templatePhone(phone) }),
+  ]);
+  if (userExists)  throw createError(400, "Username already in use");
   if (emailExists) throw createError(400, "Email already in use");
+  if (phoneExists) throw createError(400, "Phone number already in use");
 
   const newNumberPlate = templatePhone(phone);
 

--- a/server/services/userService.js
+++ b/server/services/userService.js
@@ -12,8 +12,28 @@ const ALLOWED_UPDATE_FIELDS = ['username', 'email', 'phone', 'isAdmin', 'passwor
 
 const updateUser = async (req) => {
   const { password, phone } = req.body;
-  const user = await User.findById(req.params.id);
+  const { username, email } = req.body;
+  const userId = req.params.id;
+
+  const user = await User.findById(userId);
   if (!user) throw createError(404, "User not found");
+
+  // Check uniqueness for fields being changed
+  if (username && username !== user.username) {
+    const taken = await User.findOne({ username, _id: { $ne: userId } });
+    if (taken) throw createError(400, "Username already in use");
+  }
+  if (email && email !== user.email) {
+    const taken = await User.findOne({ email, _id: { $ne: userId } });
+    if (taken) throw createError(400, "Email already in use");
+  }
+  if (phone) {
+    const formattedPhone = templatePhone(phone);
+    if (formattedPhone !== user.phone) {
+      const taken = await User.findOne({ phone: formattedPhone, _id: { $ne: userId } });
+      if (taken) throw createError(400, "Phone number already in use");
+    }
+  }
 
   // Only pick allowed fields from the request body
   const safeBody = pickAllowed(req.body, ALLOWED_UPDATE_FIELDS);


### PR DESCRIPTION
## What
Two changes:

**`authService.register`**: Added parallel uniqueness check for `phone` (via `templatePhone`) alongside the existing `username` and `email` checks using `Promise.all` — one DB round-trip instead of three sequential ones.

**`userService.updateUser`**: Added pre-update conflict checks for `username`, `email`, and `phone`. Each check skips the current user (`_id: { $ne: userId }`) so updating your own profile without changing a field doesn't trigger a false conflict.

## Why
Closes #1 — `phone` had a `unique` DB index but no explicit check, so conflicts produced a cryptic MongoDB duplicate-key error. `updateUser` had no uniqueness checks at all, allowing the DB to throw an unhelpful error when a username/email/phone conflicted with another user.

## Test plan
- [ ] Register with a phone already in use → 400 "Phone number already in use"
- [ ] Register with username already taken → 400 "Username already in use"
- [ ] Register with email already taken → 400 "Email already in use"
- [ ] `PUT /api/users/:id` changing username to one taken by another user → 400
- [ ] `PUT /api/users/:id` keeping same username (no change) → 200, no conflict error

🤖 Generated with [Claude Code](https://claude.com/claude-code)