### PR TITLE
fix: truncate review descriptions at 100 chars with see-more toggle (closes #16)

### DIFF
--- a/client/src/components/landing/reviews/Review.jsx
+++ b/client/src/components/landing/reviews/Review.jsx
@@ -1,10 +1,19 @@
-import { memo } from "react";
+import { memo, useState } from "react";
 import PropTypes from "prop-types";
 import StarRating from "./starRating/StarRating";
 import { getMomentFromUpdatedAt } from "../../../utils";
 
+const MAX_CHARS = 100;
+
 const Review = memo(({ customer }) => {
   const { theTimeAgo, theDate } = getMomentFromUpdatedAt(customer.updatedAt);
+  const [expanded, setExpanded] = useState(false);
+
+  const isLong = customer.description.length > MAX_CHARS;
+  const displayText =
+    isLong && !expanded
+      ? customer.description.slice(0, MAX_CHARS) + "…"
+      : customer.description;
 
   return (
     <div className="review-card">
@@ -23,7 +32,18 @@ const Review = memo(({ customer }) => {
         <span className="review-stars-text">{customer.stars}/5</span>
       </div>
 
-      <p className="review-description">{customer.description}</p>
+      <p className="review-description">
+        {displayText}
+        {isLong && (
+          <button
+            className="review-see-more"
+            onClick={() => setExpanded((e) => !e)}
+            aria-expanded={expanded}
+          >
+            {expanded ? " see less" : " see more"}
+          </button>
+        )}
+      </p>
 
       <div className="review-footer">
         <span className="review-time">{theTimeAgo}</span>

--- a/client/src/components/landing/reviews/reviews.css
+++ b/client/src/components/landing/reviews/reviews.css
@@ -109,11 +109,17 @@
   color: var(--review-text);
   margin-bottom: 20px;
   flex: 1;
-  display: -webkit-box;
-  -webkit-line-clamp: 6;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-  text-overflow: ellipsis;
+}
+
+.review-see-more {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--review-primary);
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-decoration: underline;
 }
 
 .review-footer {


### PR DESCRIPTION
## What
- Review card descriptions longer than 100 characters are now truncated with "…" by default
- A "see more" / "see less" toggle button appears inline when description exceeds the limit
- Removed the CSS `-webkit-line-clamp` approach in favour of JS-controlled truncation (consistent across all browsers)
- Added `.review-see-more` button style matching the primary brand colour

## Why
Closes #16 — cards with short and long descriptions had different heights. Capping at 100 chars keeps all cards visually uniform at the initial `min-height: 300px`.

## Test plan
- [ ] Review with description ≤ 100 chars — no button appears, full text shown
- [ ] Review with description > 100 chars — truncated text + "see more" appears
- [ ] Click "see more" — full description shows, button changes to "see less"
- [ ] Click "see less" — returns to truncated view

🤖 Generated with [Claude Code](https://claude.com/claude-code)