### PR TITLE
fix: show field-specific name in required error (closes #27)

### DIFF
--- a/client/src/components/form/FormInput.jsx
+++ b/client/src/components/form/FormInput.jsx
@@ -22,7 +22,8 @@ export default function FormInput({
       !valid(inputRef?.current?.value, input.name));
   let errorMessage = null;
   if (showError && !inputRef?.current?.value) {
-    errorMessage = "This field is required";
+    const fieldName = input.name.replace(/([A-Z])/g, " $1").trim();
+    errorMessage = `${fieldName} is required`;
   } else if (showError) {
     errorMessage = inputType(input).errorMessage;
   }


### PR DESCRIPTION
## What
Changed the empty-field validation error from the generic `"This field is required"` to `"<fieldName> is required"` where `fieldName` is derived from `input.name`. camelCase names (e.g. `firstName`) are split into words (`first Name`); the CSS `text-transform: capitalize` then renders it as `First Name is required`.

## Why
Closes #27 — the generic message gave no context about which field was empty. The field-specific message is immediately actionable.

## Test plan
- [ ] Submit an empty login form — errors should read "username is required" and "password is required"
- [ ] Submit a registration form with empty fields — each field shows its own name in the error
- [ ] `firstName` field → "first Name is required" (capitalize CSS handles display)

🤖 Generated with [Claude Code](https://claude.com/claude-code)