### PR TITLE
fix: harden backend — security, ownership, and reliability gaps

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -24,6 +24,11 @@ if (!process.env.JWT) {
   process.exit(1);
 }
 
+if (!process.env.ANTHROPIC_API_KEY) {
+  console.error("FATAL: ANTHROPIC_API_KEY is not defined in environment variables");
+  process.exit(1);
+}
+
 const app = express();
 const port = process.env.PORT || 8800;
 
@@ -69,10 +74,22 @@ app.use((req, res) => {
 
 app.use(errorHandler);
 
+process.on("unhandledRejection", (reason) => {
+  console.error("Unhandled promise rejection:", reason);
+});
+
 async function start() {
   await connectDB();
-  app.listen(port, () => {
+  const server = app.listen(port, () => {
     console.log("connected to backend!");
   });
+
+  const shutdown = () => {
+    server.close(() => {
+      process.exit(0);
+    });
+  };
+  process.on("SIGTERM", shutdown);
+  process.on("SIGINT", shutdown);
 }
 start();

--- a/server/models/Message.js
+++ b/server/models/Message.js
@@ -6,7 +6,7 @@ const MessageSchema = new Schema(
     from: {
       type: SchemaTypes.ObjectId,
       ref: "User",
-      required: true,
+      required: false, // null for public (anonymous) messages
     },
     to: {
       type: SchemaTypes.ObjectId,

--- a/server/routes/messages.js
+++ b/server/routes/messages.js
@@ -22,21 +22,21 @@ adminRouter.use(verifyAdmin);
 adminRouter.get("/", getMessages);
 adminRouter.get("/populate", getMessagesByType);
 
-// User routes
+// User routes — verifyUser checks req.user.id === req.params.id (user ID routes only)
 const userRouter = express.Router();
 userRouter.use(verifyUser);
 userRouter.get("/user/:id", getMessageByUser);
-userRouter.put("/:id", updateMessage);
-userRouter.delete("/:id", deleteMessage);
-userRouter.get("/:id", getMessage);
 
-// Token routes
-const tokenRouter = express.Router();
-tokenRouter.use(verifyToken);
-tokenRouter.post("/:from/:to", createMessage);
+// Auth routes — verifyToken only; ownership is enforced inside the service
+const authRouter = express.Router();
+authRouter.use(verifyToken);
+authRouter.put("/:id", updateMessage);
+authRouter.delete("/:id", deleteMessage);
+authRouter.get("/:id", getMessage);
+authRouter.post("/:from/:to", createMessage);
 
 router.use(adminRouter);
 router.use(userRouter);
-router.use(tokenRouter);
+router.use(authRouter);
 
 export default router;

--- a/server/services/appointmentService.js
+++ b/server/services/appointmentService.js
@@ -1,7 +1,7 @@
 import Appointment from "../models/Appointment.js";
 import { templatePhone } from "../utils/templates.js";
 import { createError } from "../utils/error.js";
-import { pickAllowed } from "../utils/queryHelpers.js";
+import { pickAllowed, getPaginationParams } from "../utils/queryHelpers.js";
 
 const ALLOWED_APPOINTMENT_CREATE_FIELDS = ['clientName', 'email', 'phone', 'date', 'time', 'notes', 'user'];
 
@@ -16,16 +16,20 @@ const createAppointment = async (req) => {
   return savedAppointment;
 };
 
-const getAppointments = async () => {
+const getAppointments = async (req) => {
+  const { limit, page } = getPaginationParams(req);
   const appointments = await Appointment.find()
     .populate('user', 'username email phone')
-    .sort({ date: -1, createdAt: -1 });
+    .sort({ date: -1, createdAt: -1 })
+    .skip((page - 1) * limit)
+    .limit(limit);
   return appointments;
 };
 
 const getAppointment = async (req) => {
   const appointment = await Appointment.findById(req.params.id)
     .populate('user', 'username email phone');
+  if (!appointment) throw createError(404, "Appointment not found");
   return appointment;
 };
 

--- a/server/services/carService.js
+++ b/server/services/carService.js
@@ -52,6 +52,7 @@ const deleteCar = async (req) => {
 };
 const getCar = async (req) => {
   const car = await Car.findById(req.params.id).populate("services");
+  if (!car) throw createError(404, "Car not found");
   return car;
 };
 
@@ -78,9 +79,11 @@ const getCarsWithService = async (req) => {
 };
 
 const getCarsByOwner = async (req) => {
-  const cars = await Car.find({ owner: req.params.user }).populate(
-    "services"
-  );
+  const { limit, page } = getPaginationParams(req);
+  const cars = await Car.find({ owner: req.params.user })
+    .populate("services")
+    .skip((page - 1) * limit)
+    .limit(limit);
   return cars;
 };
 

--- a/server/services/messageService.js
+++ b/server/services/messageService.js
@@ -18,7 +18,7 @@ const createMessage = async (req) => {
   });
   return savedMessage;
 };
-const ALLOWED_PUBLIC_MESSAGE_FIELDS = ['content', 'subject'];
+const ALLOWED_PUBLIC_MESSAGE_FIELDS = ['title', 'description'];
 
 const createMessageToAdmin = async (req) => {
   const to = req.params.to;
@@ -32,24 +32,43 @@ const createMessageToAdmin = async (req) => {
 };
 
 const updateMessage = async (req) => {
+  const message = await Message.findById(req.params.id);
+  if (!message) throw createError(404, "Message not found");
+  if (message.to.toString() !== req.user.id && !req.user.isAdmin) {
+    throw createError(403, "Not authorized to update this message");
+  }
   const updatedMessage = await Message.findByIdAndUpdate(
     req.params.id,
-    {
-      $set: { read: true },
-    },
+    { $set: { read: true } },
     { new: true }
   );
-  if (!updatedMessage) throw createError(404, "Message not found");
   return updatedMessage;
 };
 
 const deleteMessage = async (req) => {
+  const message = await Message.findById(req.params.id);
+  if (!message) throw createError(404, "Message not found");
+  const userId = req.user.id;
+  const isParticipant =
+    message.from?.toString() === userId ||
+    message.to.toString() === userId;
+  if (!isParticipant && !req.user.isAdmin) {
+    throw createError(403, "Not authorized to delete this message");
+  }
   await Message.findByIdAndDelete(req.params.id);
   return "The Message has been removed";
 };
 
 const getMessage = async (req) => {
   const message = await Message.findById(req.params.id);
+  if (!message) throw createError(404, "Message not found");
+  const userId = req.user.id;
+  const isParticipant =
+    message.from?.toString() === userId ||
+    message.to.toString() === userId;
+  if (!isParticipant && !req.user.isAdmin) {
+    throw createError(403, "Not authorized to view this message");
+  }
   return message;
 };
 
@@ -71,7 +90,8 @@ const getMessagesByType = async (req) => {
   if (!ALLOWED_MESSAGE_POPULATE_FIELDS.includes(type)) {
     throw createError(400, `Invalid populate field. Allowed: ${ALLOWED_MESSAGE_POPULATE_FIELDS.join(', ')}`);
   }
-  const messages = await Message.find().populate(type);
+  const { limit, page } = getPaginationParams(req);
+  const messages = await Message.find().populate(type).skip((page - 1) * limit).limit(limit);
   return messages;
 };
 

--- a/server/services/serviceService.js
+++ b/server/services/serviceService.js
@@ -22,27 +22,24 @@ const createService = async (req) => {
   const newService = new Service(serviceData);
   
   try {
-    // Save the service
     const savedService = await newService.save();
-    
-    // Update the car with the service reference
+
     try {
       await Car.findByIdAndUpdate(carId, {
         $push: { services: savedService._id },
       });
     } catch (error) {
-      // If car update fails, delete the service we just created to maintain consistency
       await Service.findByIdAndDelete(savedService._id);
-      throw Error(`Failed to update car with service: ${error.message}`);
+      throw createError(500, `Failed to update car with service: ${error.message}`);
     }
-    
+
     return savedService;
   } catch (error) {
-    // Provide more helpful error message for duplicate key errors
+    if (error.status) throw error; // already a createError
     if (error.code === 11000) {
-      throw Error(`Duplicate service entry: ${error.message}`);
+      throw createError(400, "Duplicate service entry");
     }
-    throw Error(`Failed to create service: ${error.message}`);
+    throw createError(500, `Failed to create service: ${error.message}`);
   }
 };
 
@@ -53,15 +50,18 @@ const updateService = async (req) => {
     { $set: safeBody },
     { new: true }
   );
+  if (!updatedService) throw createError(404, "Service not found");
   return updatedService;
 };
 
 const deleteService = async (req) => {
-  await Service.findByIdAndDelete(req.params.id);
+  const deleted = await Service.findByIdAndDelete(req.params.id);
+  if (!deleted) throw createError(404, "Service not found");
 };
 
 const getService = async (req) => {
   const service = await Service.findById(req.params.id);
+  if (!service) throw createError(404, "Service not found");
   return service;
 };
 
@@ -90,7 +90,10 @@ const getServicesByUser = async (req) => {
   if (req.user.id !== req.params.user && !req.user.isAdmin) {
     throw createError(403, "Not authorized");
   }
-  const services = await Service.find({ user: req.params.user });
+  // Service has no user field — resolve via the user's cars
+  const cars = await Car.find({ owner: req.params.user }).select("_id").lean();
+  const carIds = cars.map((c) => c._id);
+  const services = await Service.find({ car: { $in: carIds } });
   return services;
 };
 


### PR DESCRIPTION
## Summary

- **4 Critical security/correctness bugs fixed** — broken public messages, wrong field allowlist, ownership check comparing wrong IDs, service query on non-existent field
- **Ownership enforcement added** to message read/delete/view operations
- **Pagination added** to 3 unbounded list endpoints
- **Reliability hardened** — startup validation, graceful shutdown, unhandled rejection handler

## Changes

### 🔴 Critical
| File | Fix |
|------|-----|
| `models/Message.js` | `from` changed to `required: false` — anonymous public messages were always failing Mongoose validation |
| `services/messageService.js` | `ALLOWED_PUBLIC_MESSAGE_FIELDS`: `['content','subject']` → `['title','description']` — fields were being filtered out, resulting in empty messages |
| `routes/messages.js` | Separated `verifyUser` (user-ID routes) from `verifyToken` (message-ID routes) — `verifyUser` was comparing `req.user.id` to the **message ID**, so non-admins could never update/delete their own messages |
| `services/serviceService.js` | `getServicesByUser`: queried `Service.find({ user })` but `Service` has no `user` field — always returned `[]`; now resolves via `Car.find({ owner }) → $in` |

### 🟡 Medium
- **`index.js`**: `ANTHROPIC_API_KEY` validated at startup; graceful `SIGTERM`/`SIGINT` shutdown; `unhandledRejection` process handler
- **404 guards**: `getMessage`, `getAppointment`, `getCar`, `getService`, `updateService`, `deleteService` (all previously returned `null` with 200)
- **Ownership checks** in `updateMessage`, `deleteMessage`, `getMessage` — only participants (from/to) or admins can act on a message
- **`createService`**: replaced `throw Error()` with `throw createError()` so the error handler returns correct HTTP status codes (was returning 500 for known 400-type errors)
- **Pagination**: added to `getAppointments`, `getMessagesByType`, `getCarsByOwner`

## Test plan

- [ ] `POST /api/messages/to/:adminId` with `{ title, description }` — should save and return 201
- [ ] Non-admin user: `DELETE /api/messages/:id` for a message they sent — should return 200
- [ ] Non-admin user: `DELETE /api/messages/:id` for a message they did NOT send — should return 403
- [ ] `GET /api/services/user/:userId` — should return services for all cars owned by that user (not [])
- [ ] `GET /api/appointments` without `?limit` — should return paginated results (default 500)
- [ ] Stop server with Ctrl+C — should exit cleanly without hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)