### PR TITLE
fix: require authentication on POST /messages/to/:to (closes #41)

### DIFF
--- a/server/routes/messages.js
+++ b/server/routes/messages.js
@@ -13,9 +13,6 @@ import { verifyAdmin, verifyToken, verifyUser } from "../utils/verifyToken.js";
 
 const router = express.Router();
 
-// Public routes
-router.post("/to/:to", createMessageToAdmin);
-
 // Admin routes
 const adminRouter = express.Router();
 adminRouter.use(verifyAdmin);
@@ -30,6 +27,7 @@ userRouter.get("/user/:id", getMessageByUser);
 // Auth routes — verifyToken only; ownership is enforced inside the service
 const authRouter = express.Router();
 authRouter.use(verifyToken);
+authRouter.post("/to/:to", createMessageToAdmin);
 authRouter.put("/:id", updateMessage);
 authRouter.delete("/:id", deleteMessage);
 authRouter.get("/:id", getMessage);

--- a/server/services/messageService.js
+++ b/server/services/messageService.js
@@ -18,12 +18,12 @@ const createMessage = async (req) => {
   });
   return savedMessage;
 };
-const ALLOWED_PUBLIC_MESSAGE_FIELDS = ['title', 'description'];
+const ALLOWED_MESSAGE_FIELDS = ['title', 'description'];
 
 const createMessageToAdmin = async (req) => {
   const to = req.params.to;
-  const safeBody = pickAllowed(req.body, ALLOWED_PUBLIC_MESSAGE_FIELDS);
-  const newMessage = new Message({ ...safeBody, to, from: null });
+  const safeBody = pickAllowed(req.body, ALLOWED_MESSAGE_FIELDS);
+  const newMessage = new Message({ ...safeBody, to, from: req.user.id });
   const savedMessage = await newMessage.save();
   await User.findByIdAndUpdate(to, {
     $push: { messages: [savedMessage._id] },


### PR DESCRIPTION
## What
Moves `POST /api/messages/to/:to` out of the public section and into the `verifyToken` sub-router. Updates `createMessageToAdmin` in the service to record `req.user.id` as the `from` field instead of always writing `null`.

## Why
Closes #41 — the endpoint was fully public, allowing any anonymous actor to flood the admin inbox. Existing partial mitigations (`publicLimiter`, `pickAllowed`) reduced the attack surface but did not eliminate unauthenticated access.

## Test plan
- [ ] Unauthenticated POST to `/api/messages/to/<adminId>` returns 401
- [ ] Authenticated POST creates the message with `from` set to the caller's user ID
- [ ] Existing authenticated flows (contact form, service request) continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)