### PR TITLE
fix: replace hardcoded ADMIN_ID with dynamic server lookup (closes #44)

### DIFF
--- a/client/src/api/apiEndpoints.js
+++ b/client/src/api/apiEndpoints.js
@@ -8,6 +8,3 @@ export const API_URL_REVIEWS = "/reviews";
 export const API_URL_CONTACTS = "/contacts";
 export const API_URL_APPOINTMENTS = "/appointments";
 export const API_URL_DASHBOARD = "/dashboard";
-
-// Admin user ID
-export const ADMIN_ID = "63e14deca4340e45d23f20b2";

--- a/client/src/api/services/messageApi.js
+++ b/client/src/api/services/messageApi.js
@@ -1,8 +1,17 @@
 import axios from "../../axiosConfig.js";
 import { createCrudOperations } from "../crudOperations.js";
-import { API_URL_MESSAGES, ADMIN_ID } from "../apiEndpoints.js";
+import { API_URL_MESSAGES } from "../apiEndpoints.js";
 
 const messageOps = createCrudOperations(API_URL_MESSAGES);
+
+let _cachedAdminId = null;
+const getAdminId = async () => {
+  if (!_cachedAdminId) {
+    const { data } = await axios.get("/auth/admin-id");
+    _cachedAdminId = data.adminId;
+  }
+  return _cachedAdminId;
+};
 
 /**
  * Message API operations
@@ -10,25 +19,26 @@ const messageOps = createCrudOperations(API_URL_MESSAGES);
 export const messageApi = {
   // Get all messages
   getAll: messageOps.getAll,
-  
+
   // Get message by ID
   getById: messageOps.getById,
-  
+
   // Create message to specific user
   create: async (data, toUserId) => {
     const response = await axios.post(`${API_URL_MESSAGES}/to/${toUserId}`, data);
     return response.data;
   },
-  
+
   // Create message to admin
   createToAdmin: async (data) => {
-    const response = await axios.post(`${API_URL_MESSAGES}/to/${ADMIN_ID}`, data);
+    const adminId = await getAdminId();
+    const response = await axios.post(`${API_URL_MESSAGES}/to/${adminId}`, data);
     return response.data;
   },
 
   // Create service request — same endpoint as createToAdmin
   createServiceRequest(data) { return messageApi.createToAdmin(data); },
-  
+
   // Delete message
   delete: messageOps.delete,
 };

--- a/client/src/stores/userStore.js
+++ b/client/src/stores/userStore.js
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import axios from "../axiosConfig.js";
 import { getUserId } from "../api/services/userApi.js";
-import { ADMIN_ID } from "../api/apiEndpoints.js";
+import { messageApi } from "../api/services/messageApi.js";
 import { setErr } from "./storeUtils.js";
 
 const API = {
@@ -53,7 +53,7 @@ export const useUserStore = create((set) => {
     createReqService: async (dataMessage) => {
       set({ isLoading: true });
       try {
-        const { data } = await axios.post(`${API.messages}/to/${ADMIN_ID}`, dataMessage);
+        const data = await messageApi.createToAdmin(dataMessage);
         set({ isLoading: false });
         return data;
       } catch (err) { setErr(set, err); }

--- a/server/controllers/auth.js
+++ b/server/controllers/auth.js
@@ -4,6 +4,9 @@ import { createHandler } from "../utils/controllerFactory.js";
 // Register handler using shared factory
 export const register = createHandler(authService.register, 201);
 
+// Admin ID lookup — authenticated users only
+export const getAdminId = createHandler(authService.getAdminId, 200);
+
 // Login has custom cookie handling, keep it as-is
 export const login = async (req, res, next) => {
   try {

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,17 +1,23 @@
 import express from "express";
-import { register,login,logout } from "../controllers/auth.js";
-import { verifyAdmin} from "../utils/verifyToken.js";
+import { register, login, logout, getAdminId } from "../controllers/auth.js";
+import { verifyAdmin, verifyToken } from "../utils/verifyToken.js";
 const router = express.Router();
 
 // Public routes
 router.post("/login", login);
 router.post("/logout", logout);
 
-// Admin routes
+// Auth routes — any verified user
+const authRouter = express.Router();
+authRouter.use(verifyToken);
+authRouter.get("/admin-id", getAdminId);
+
+// Admin-only routes
 const adminRouter = express.Router();
 adminRouter.use(verifyAdmin);
 adminRouter.post("/register", register);
 
+router.use(authRouter);
 router.use(adminRouter);
 
 export default router;

--- a/server/services/authService.js
+++ b/server/services/authService.js
@@ -106,10 +106,17 @@ const logout = async () => {
   };
 };
 
+const getAdminId = async () => {
+  const admin = await User.findOne({ isAdmin: true }, "_id");
+  if (!admin) throw createError(404, "Admin user not found");
+  return { adminId: admin._id };
+};
+
 const authService = {
   register,
   login,
   logout,
+  getAdminId,
 };
 
 export default authService;


### PR DESCRIPTION
## What
- Adds `GET /api/auth/admin-id` (requires `verifyToken`) that queries the DB for a user with `isAdmin: true` and returns `{ adminId }`.
- Removes the hardcoded `ADMIN_ID` constant from `client/src/api/apiEndpoints.js`.
- `messageApi.createToAdmin` now fetches the admin ID from the server on first call and caches it for the session (module-level cache).
- `userStore.createReqService` delegates to `messageApi.createToAdmin` instead of constructing the URL directly.

## Why
Closes #44 — the admin's MongoDB ObjectId was hardcoded in the client bundle, meaning the app would silently break if the admin account were recreated with a different ID (e.g. after a data migration or environment reset).

## Test plan
- [ ] `GET /api/auth/admin-id` returns 401 for unauthenticated requests
- [ ] `GET /api/auth/admin-id` returns `{ adminId: "..." }` for authenticated users
- [ ] Sending a service request / message-to-admin works correctly (admin ID resolved dynamically)
- [ ] Second call reuses the cached ID without a second network request

🤖 Generated with [Claude Code](https://claude.com/claude-code)