### PR TITLE
fix: correct topServices field projection 'name' → 'title' (closes #113)

### DIFF
--- a/server/services/dashboardService.js
+++ b/server/services/dashboardService.js
@@ -104,7 +104,7 @@ const getDashboardStats = async () => {
   const topServices = await Service.find()
     .sort({ createdAt: -1 })
     .limit(5)
-    .select("name price");
+    .select("title price");
 
   // Get average review rating
   const reviewStats = await Review.aggregate([


### PR DESCRIPTION
## What
One-character field name fix in `dashboardService.js`: `.select("name price")` → `.select("title price")`.

## Why
Closes #113 — the `Service` Mongoose schema defines the field as `title`, not `name`. MongoDB silently excluded the field from results, so the Top Services dashboard widget always rendered blank titles.

## Test plan
- [ ] Dashboard loads without errors
- [ ] Top Services widget shows service titles instead of blank entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)