### PR TITLE
fix: 401 interceptor now clears correct Zustand auth state (closes #114)

### DIFF
--- a/client/src/axiosConfig.js
+++ b/client/src/axiosConfig.js
@@ -1,17 +1,16 @@
 import axios from "axios";
+import { useAuthStore } from "./stores/authStore.js";
 
 axios.defaults.baseURL = import.meta.env.VITE_API_URL || 'http://localhost:8800/api';
 
 axios.defaults.withCredentials = true;
 
-// httpOnly cookies are sent automatically via withCredentials=true
-// No manual token handling needed here
-
 axios.interceptors.response.use(
   (response) => response,
   async (error) => {
     if (error.response?.status === 401) {
-      localStorage.removeItem("user");
+      // clearAuth avoids an API call so this interceptor cannot loop
+      useAuthStore.getState().clearAuth();
     }
     return Promise.reject(error);
   }

--- a/client/src/stores/authStore.js
+++ b/client/src/stores/authStore.js
@@ -56,6 +56,10 @@ export const useAuthStore = create(
         set({ user: null, isError: false, isSuccess: false, message: "" });
       },
 
+      // clearAuth: clears user + flags without an API call (safe to use in interceptors)
+      clearAuth: () =>
+        set({ user: null, isError: false, isSuccess: false, isLoading: false, message: "" }),
+
       reset: () =>
         set({ isError: false, isSuccess: false, isLoading: false, message: "" }),
     }),


### PR DESCRIPTION
## What
- Adds `clearAuth()` to `authStore` — resets `user` + all flags to initial state, **without making any API call**.
- Replaces `localStorage.removeItem("user")` in the 401 interceptor with `useAuthStore.getState().clearAuth()`.

## Why
Closes #114 — the interceptor was removing the key `"user"` which no longer exists; auth state is persisted under `"auth-storage"` by Zustand. The wrong key removal left stale data in-memory, so users were never visibly logged out after token expiry.

Using a dedicated `clearAuth` (no network call) instead of `logout()` prevents an infinite-loop: `logout()` calls `POST /auth/logout` which could return another 401, re-triggering the interceptor.

## Test plan
- [ ] Let a JWT expire (or manually delete the cookie); confirm the next API call logs the user out and shows the login UI
- [ ] Normal logout flow still works (calls `POST /auth/logout` as before)
- [ ] No infinite-loop / stack overflow in the network tab when a 401 is received

🤖 Generated with [Claude Code](https://claude.com/claude-code)