### PR TITLE
fix: add field allowlist to updateAppointment (closes #115)

### DIFF
--- a/server/services/appointmentService.js
+++ b/server/services/appointmentService.js
@@ -4,6 +4,7 @@ import { createError } from "../utils/error.js";
 import { pickAllowed, getPaginationParams } from "../utils/queryHelpers.js";
 
 const ALLOWED_APPOINTMENT_CREATE_FIELDS = ['clientName', 'email', 'phone', 'date', 'time', 'notes', 'user'];
+const ALLOWED_APPOINTMENT_UPDATE_FIELDS = ['clientName', 'email', 'phone', 'date', 'time', 'notes', 'status'];
 
 const createAppointment = async (req) => {
   const { phone } = req.body;
@@ -34,12 +35,8 @@ const getAppointment = async (req) => {
 };
 
 const updateAppointment = async (req) => {
-  const { phone } = req.body;
-  const updateData = { ...req.body };
-  
-  if (phone) {
-    updateData.phone = templatePhone(phone);
-  }
+  const updateData = pickAllowed(req.body, ALLOWED_APPOINTMENT_UPDATE_FIELDS);
+  if (updateData.phone) updateData.phone = templatePhone(updateData.phone);
   
   const updatedAppointment = await Appointment.findByIdAndUpdate(
     req.params.id,


### PR DESCRIPTION
## What
Replaces the unguarded `{ ...req.body }` spread in `updateAppointment` with `pickAllowed(req.body, ALLOWED_APPOINTMENT_UPDATE_FIELDS)`, where the allowlist is `['clientName', 'email', 'phone', 'date', 'time', 'notes', 'status']`.

## Why
Closes #115 — the bare spread allowed callers to overwrite any field on an Appointment document, including `user` (re-linking the appointment to a different user) and internal timestamps. This matches the pattern already used in `createAppointment`, `updateCar`, `updateService`, and `updateUser`.

## Test plan
- [ ] Update an appointment via the UI — all normal editable fields are saved correctly
- [ ] Sending `{ user: "<another-id>" }` in the request body is silently ignored
- [ ] Sending `{ createdAt: "..." }` in the request body is silently ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)