### PR TITLE
fix: add .env.example files for server and client (closes #117)

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,3 @@
+# Base URL of the backend API (no trailing slash)
+# In development, the server runs on port 8800 by default
+VITE_API_URL=http://localhost:8800/api

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,17 @@
+# JWT signing secret — use a long random string in production
+JWT=your_jwt_secret_here
+
+# MongoDB connection string
+MONGO=mongodb+srv://<user>:<password>@<cluster>/<database>
+
+# Anthropic API key for the AI agent feature
+ANTHROPIC_API_KEY=sk-ant-api03-...
+
+# Domain used for the auth cookie in production (must match the server hostname)
+COOKIE_DOMAIN=your-server-domain.com
+
+# Port the Express server listens on (optional, defaults to 8800)
+PORT=8800
+
+# Set to "production" in deployed environments; anything else is treated as dev
+NODE_ENV=development


### PR DESCRIPTION
## What
- `server/.env.example` — documents `JWT`, `MONGO`, `ANTHROPIC_API_KEY`, `COOKIE_DOMAIN`, `PORT`, `NODE_ENV` with placeholder values and explanatory comments.
- `client/.env.example` — documents `VITE_API_URL` with the dev default.

## Why
Closes #117 — new developers had no documented way to discover the required environment variables; the actual `.env` files are gitignored.

## Test plan
- [ ] Clone the repo fresh and follow the `.env.example` files to configure a working local environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)