### PR TITLE
fix: sender impersonation, 404 guards, pagination, indexes, null guard

### DIFF
--- a/server/models/Message.js
+++ b/server/models/Message.js
@@ -37,4 +37,7 @@ const MessageSchema = new Schema(
   { timestamps: true }
 );
 
+MessageSchema.index({ to: 1 });
+MessageSchema.index({ from: 1 });
+
 export default model("Message", MessageSchema);

--- a/server/models/Service.js
+++ b/server/models/Service.js
@@ -33,4 +33,6 @@ const ServiceSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
+ServiceSchema.index({ car: 1 });
+
 export default mongoose.model("Service", ServiceSchema);

--- a/server/services/appointmentService.js
+++ b/server/services/appointmentService.js
@@ -37,12 +37,13 @@ const getAppointment = async (req) => {
 const updateAppointment = async (req) => {
   const updateData = pickAllowed(req.body, ALLOWED_APPOINTMENT_UPDATE_FIELDS);
   if (updateData.phone) updateData.phone = templatePhone(updateData.phone);
-  
+
   const updatedAppointment = await Appointment.findByIdAndUpdate(
     req.params.id,
     { $set: updateData },
     { new: true }
   ).populate('user', 'username email phone');
+  if (!updatedAppointment) throw createError(404, "Appointment not found");
   return updatedAppointment;
 };
 
@@ -53,6 +54,7 @@ const updateAppointmentStatus = async (req) => {
     { $set: { status } },
     { new: true }
   );
+  if (!updatedAppointment) throw createError(404, "Appointment not found");
   return updatedAppointment;
 };
 

--- a/server/services/messageService.js
+++ b/server/services/messageService.js
@@ -6,7 +6,7 @@ import { getPaginationParams, pickAllowed } from "../utils/queryHelpers.js";
 const ALLOWED_MESSAGE_POPULATE_FIELDS = ['from', 'to'];
 
 const createMessage = async (req) => {
-  const from = req.params.from;
+  const from = req.user.id; // always use authenticated user's ID, never trust URL param
   const to = req.params.to;
   const newMessage = new Message({ ...req.body, to, from });
   const savedMessage = await newMessage.save();
@@ -73,9 +73,14 @@ const getMessage = async (req) => {
 };
 
 const getMessageByUser = async (req) => {
+  const { limit, page } = getPaginationParams(req);
   const messages = await Message.find({
     $or: [{ to: req.params.id }, { from: req.params.id }],
-  }).populate("to").populate("from");
+  })
+    .populate("to")
+    .populate("from")
+    .skip((page - 1) * limit)
+    .limit(limit);
   return messages;
 };
 

--- a/server/utils/templates.js
+++ b/server/utils/templates.js
@@ -12,6 +12,7 @@ export function templatePhone(phone) {
 
 
 export function templateCar(car) {
+  if (!car || typeof car !== "string") return car;
   if (car.length === 8) {
     return car.slice(0, 3) + "-" + car.slice(3, 5) + "-" + car.slice(5);
   } else if (car.length === 7) {


### PR DESCRIPTION
## Summary

Second backend hardening pass — 1 critical impersonation bug + 5 medium issues.

> First pass is in #126. This PR is independent and can be merged in any order.

## Changes

### 🔴 Critical

| File | Fix |
|------|-----|
| `services/messageService.js` | `createMessage`: replaced `req.params.from` with `req.user.id` — the `from` field came from the URL path, allowing any authenticated user to send a message that appears to be from another user's ID |

### 🟡 Medium

| File | Fix |
|------|-----|
| `services/appointmentService.js` | `updateAppointment` + `updateAppointmentStatus`: add 404 throw when `findByIdAndUpdate` returns null (previously returned `null` with HTTP 200) |
| `services/messageService.js` | `getMessageByUser`: add pagination — unbounded query on a user's full message history |
| `models/Message.js` | Add indexes on `to` and `from` — `getMessageByUser` runs `$or: [{ to }, { from }]` on every page load with no index |
| `models/Service.js` | Add index on `car` — `getServicesByCar` and `getServicesByUser` both query by car with no index |

### 🟢 Low

| File | Fix |
|------|-----|
| `utils/templates.js` | `templateCar`: add null/undefined guard matching `templatePhone` — passing undefined throws on `.length` |

## Test plan

- [ ] `POST /api/messages/:from/:to` — confirm the saved message has `from = req.user.id`, not the URL param value
- [ ] `PUT /api/appointments/:invalidId` — should return 404, not `null`/200
- [ ] `PATCH /api/appointments/:invalidId/status` — should return 404, not `null`/200
- [ ] `GET /api/messages/user/:id?limit=10&page=1` — should return paginated results

🤖 Generated with [Claude Code](https://claude.com/claude-code)