### PR TITLE
fix: block _id injection, missing pagination, index Car.owner

### DIFF
--- a/server/models/Car.js
+++ b/server/models/Car.js
@@ -38,4 +38,6 @@ const CarSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
+CarSchema.index({ owner: 1 });
+
 export default mongoose.model("Car", CarSchema);

--- a/server/services/appointmentService.js
+++ b/server/services/appointmentService.js
@@ -65,7 +65,11 @@ const deleteAppointment = async (req) => {
 
 const getAppointmentsByStatus = async (req) => {
   const { status } = req.query;
-  const appointments = await Appointment.find({ status }).sort({ date: -1 });
+  const { limit, page } = getPaginationParams(req);
+  const appointments = await Appointment.find({ status })
+    .sort({ date: -1 })
+    .skip((page - 1) * limit)
+    .limit(limit);
   return appointments;
 };
 
@@ -87,12 +91,16 @@ const getAppointmentsByDateRange = async (req) => {
     throw createError(400, "startDate must be before endDate");
   }
 
+  const { limit, page } = getPaginationParams(req);
   const appointments = await Appointment.find({
     date: {
       $gte: start,
       $lte: end,
     },
-  }).sort({ date: 1 });
+  })
+    .sort({ date: 1 })
+    .skip((page - 1) * limit)
+    .limit(limit);
   return appointments;
 };
 

--- a/server/services/carService.js
+++ b/server/services/carService.js
@@ -6,13 +6,14 @@ import { getPaginationParams, pickAllowed } from "../utils/queryHelpers.js";
 
 const ALLOWED_CAR_POPULATE_FIELDS = ['services', 'owner'];
 const ALLOWED_CAR_UPDATE_FIELDS = ['numberPlate', 'km', 'brand'];
+const ALLOWED_CAR_CREATE_FIELDS = ['numberPlate', 'km', 'brand'];
 
 const createCar = async (req) => {
   const userId = req.params.userId;
-  const { numberPlate } = req.body;
-  const newNumberPlate = templateCar(numberPlate);
+  const safeBody = pickAllowed(req.body, ALLOWED_CAR_CREATE_FIELDS);
+  const newNumberPlate = templateCar(safeBody.numberPlate);
   const newCar = new Car({
-    ...req.body,
+    ...safeBody,
     owner: userId,
     numberPlate: newNumberPlate,
   });

--- a/server/services/contactService.js
+++ b/server/services/contactService.js
@@ -1,12 +1,14 @@
 import Contact from "../models/Contact.js";
 import { templatePhone } from "../utils/templates.js";
-import { getPaginationParams } from "../utils/queryHelpers.js";
+import { getPaginationParams, pickAllowed } from "../utils/queryHelpers.js";
+
+const ALLOWED_CONTACT_FIELDS = ['firstName', 'lastName', 'email', 'phone', 'message'];
 
 const createContact = async (req) => {
-  const { phone } = req.body;
-  const newPhone = templatePhone(phone);
+  const safeBody = pickAllowed(req.body, ALLOWED_CONTACT_FIELDS);
+  const newPhone = templatePhone(safeBody.phone);
   const newContact = new Contact({
-    ...req.body,
+    ...safeBody,
     phone: newPhone,
   });
   const savedContact = await newContact.save();

--- a/server/services/messageService.js
+++ b/server/services/messageService.js
@@ -8,7 +8,8 @@ const ALLOWED_MESSAGE_POPULATE_FIELDS = ['from', 'to'];
 const createMessage = async (req) => {
   const from = req.user.id; // always use authenticated user's ID, never trust URL param
   const to = req.params.to;
-  const newMessage = new Message({ ...req.body, to, from });
+  const safeBody = pickAllowed(req.body, ALLOWED_MESSAGE_FIELDS);
+  const newMessage = new Message({ ...safeBody, to, from });
   const savedMessage = await newMessage.save();
   await User.findByIdAndUpdate(from, {
     $push: { messages: [savedMessage._id] },

--- a/server/services/serviceService.js
+++ b/server/services/serviceService.js
@@ -5,21 +5,12 @@ import { getPaginationParams, pickAllowed } from "../utils/queryHelpers.js";
 
 const ALLOWED_SERVICE_POPULATE_FIELDS = ['car'];
 const ALLOWED_SERVICE_UPDATE_FIELDS = ['title', 'description', 'price', 'paid', 'status'];
-/**
- * Creates a new service and associates it with a car
- * @param {Object} req - Express request object
- * @returns {Promise<Object>} Created service
- */
+const ALLOWED_SERVICE_CREATE_FIELDS = ['title', 'description', 'price', 'paid', 'status'];
+
 const createService = async (req) => {
   const carId = req.params.carId;
-  
-  // Create a new service object from request body but WITHOUT any _id field
-  const serviceData = { ...req.body, car: carId };
-  
-  // Delete _id property if it exists to ensure MongoDB generates a new unique ID
-  delete serviceData._id;
-  
-  const newService = new Service(serviceData);
+  const safeBody = pickAllowed(req.body, ALLOWED_SERVICE_CREATE_FIELDS);
+  const newService = new Service({ ...safeBody, car: carId });
   
   try {
     const savedService = await newService.save();
@@ -82,7 +73,10 @@ const getServicesByType = async (req) => {
 };
 
 const getServicesByCar = async (req) => {
-  const services = await Service.find({ car: req.params.car });
+  const { limit, page } = getPaginationParams(req);
+  const services = await Service.find({ car: req.params.car })
+    .skip((page - 1) * limit)
+    .limit(limit);
   return services;
 };
 


### PR DESCRIPTION
## Summary

Third backend hardening pass — no new critical bugs, 8 medium issues closed.

> Previous passes: #126 (critical security fixes), #135 (impersonation + indexes).

## Changes

### 🟡 Security — req.body spread without pickAllowed

All four `create*` functions were spreading `req.body` directly into the Mongoose constructor. Mongoose strict mode discards unknown fields, but valid schema fields (like `services[]` on Car or `_id` on any model) could be injected by a malicious client.

| File | Fix |
|------|-----|
| `services/carService.js` | `createCar`: `pickAllowed(['numberPlate','km','brand'])` — prevents pre-populating `services[]` |
| `services/contactService.js` | `createContact`: `pickAllowed([...contact fields])` — prevents custom `_id` injection |
| `services/messageService.js` | `createMessage`: apply existing `ALLOWED_MESSAGE_FIELDS` to this function (was only used in `createMessageToAdmin`) |
| `services/serviceService.js` | `createService`: `pickAllowed([...service fields])` — removes raw spread + manual `delete _id` |

### 🟡 Performance — unbounded list queries

| File | Fix |
|------|-----|
| `services/appointmentService.js` | `getAppointmentsByStatus`: add pagination — full table scan filtered by status |
| `services/appointmentService.js` | `getAppointmentsByDateRange`: add pagination — wide date ranges can return thousands of records |
| `services/serviceService.js` | `getServicesByCar`: add pagination — a high-activity car can accumulate many service records |

### 🟡 Performance — missing index

| File | Fix |
|------|-----|
| `models/Car.js` | Add `index({ owner: 1 })` — `getCarsByOwner` runs `Car.find({ owner })` on every user page load |

## Test plan

- [ ] `POST /api/cars/:userId` with `{ numberPlate, km, brand, services: ["id1"] }` — `services` should NOT be populated on the saved car
- [ ] `POST /api/contacts` with `{ _id: "custom_id", ... }` — saved contact should have a MongoDB-generated `_id`
- [ ] `GET /api/appointments?status=pending&limit=10&page=1` — should return paginated results
- [ ] `GET /api/appointments/date-range?startDate=...&endDate=...&limit=5` — should respect limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)