### PR TITLE
refactor: extract remaining logic from JSX into hooks (run 2)

### DIFF
--- a/client/src/components/landing/contact/Contact.jsx
+++ b/client/src/components/landing/contact/Contact.jsx
@@ -1,20 +1,10 @@
 import "./contact.css";
-import { useState } from "react";
 import { Form } from "../../index";
-import { createContact } from "../../../utils";
-//TODO: CONTACT US ON VALIDATE PHONE,EMAIL 
+import { useContactLegacyForm } from "./hooks/useContactLegacyForm";
+//TODO: CONTACT US ON VALIDATE PHONE,EMAIL
 //TODO: SERVER:MODEL,ROUTES,SERVICES,CONTROLLERS
 const Contact = () => {
-  const [formData, setFormData] = useState({
-    from: "",
-    title: "",
-    description: "",
-  });
-
-  const onSubmit = async(e) => {
-    e.preventDefault();
-    await createContact(formData);
-  };
+  const { setFormData, onSubmit } = useContactLegacyForm();
   
   return (
     <div id="contact">

--- a/client/src/components/landing/contact/hooks/useContactLegacyForm.js
+++ b/client/src/components/landing/contact/hooks/useContactLegacyForm.js
@@ -1,0 +1,13 @@
+import { useState } from "react";
+import { createContact } from "../../../../utils";
+
+export function useContactLegacyForm() {
+  const [formData, setFormData] = useState({ from: "", title: "", description: "" });
+
+  const onSubmit = async (e) => {
+    e.preventDefault();
+    await createContact(formData);
+  };
+
+  return { formData, setFormData, onSubmit };
+}

--- a/client/src/pages/account/Account.jsx
+++ b/client/src/pages/account/Account.jsx
@@ -1,17 +1,10 @@
 import "./account.css";
-import { useEffect } from "react";
 import ReqService from "../../components/create/ReqService";
 import AccountTables from "./AccountTables";
-import { useAccountUIStore } from "../../stores/uiStores";
-import { useUserStore } from "../../stores/userStore";
+import { useAccountInit } from "./hooks/useAccountInit";
 
 const Account = () => {
-  const selectedCar = useAccountUIStore((s) => s.selectedCar);
-  const getServicesByIdCar = useUserStore((s) => s.getServicesByIdCar);
-
-  useEffect(() => {
-    getServicesByIdCar(selectedCar?._id);
-  }, [selectedCar, getServicesByIdCar]);
+  useAccountInit();
 
   return (
     <>

--- a/client/src/pages/account/AccountTable.jsx
+++ b/client/src/pages/account/AccountTable.jsx
@@ -1,20 +1,9 @@
-import { useCallback } from "react";
 import Search from "../../components/table/Search";
 import Table from "../../components/table/Table";
-import { useUserStore } from "../../stores/userStore";
-import { useAccountUIStore } from "../../stores/uiStores";
-import useFilteredData from "../../hooks/useFilteredData";
-import { carFilterFn } from "./utils/accountValidation";
-import { handleCarAction as handleCarActionUtil } from "./utils/accountHandlerUtils";
+import { useAccountTableData } from "./hooks/useAccountTableData";
 
 export default function AccountTable() {
-  const user = useUserStore((s) => s.user);
-  const { setSelectedCar, toggleReqService, toggleServices } = useAccountUIStore();
-
-  const memoizedCarFilterFn = useCallback(carFilterFn, []);
-  const { displayData: displayCars, handleSearch } = useFilteredData(user?.cars, memoizedCarFilterFn);
-
-  const handleCar = (e) => handleCarActionUtil(e, user?.cars, setSelectedCar, { toggleReqService, toggleServices });
+  const { displayCars, handleSearch, handleCar } = useAccountTableData();
   const trTh = (
     <tr>
       <th>brand</th>

--- a/client/src/pages/account/hooks/useAccountInit.js
+++ b/client/src/pages/account/hooks/useAccountInit.js
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useAccountUIStore } from "../../../stores/uiStores";
+import { useUserStore } from "../../../stores/userStore";
+
+export function useAccountInit() {
+  const selectedCar = useAccountUIStore((s) => s.selectedCar);
+  const getServicesByIdCar = useUserStore((s) => s.getServicesByIdCar);
+
+  useEffect(() => {
+    getServicesByIdCar(selectedCar?._id);
+  }, [selectedCar, getServicesByIdCar]);
+}

--- a/client/src/pages/account/hooks/useAccountTableData.js
+++ b/client/src/pages/account/hooks/useAccountTableData.js
@@ -1,0 +1,22 @@
+import { useCallback } from "react";
+import { useUserStore } from "../../../stores/userStore";
+import { useAccountUIStore } from "../../../stores/uiStores";
+import useFilteredData from "../../../hooks/useFilteredData";
+import { carFilterFn } from "../utils/accountValidation";
+import { handleCarAction as handleCarActionUtil } from "../utils/accountHandlerUtils";
+
+export function useAccountTableData() {
+  const user = useUserStore((s) => s.user);
+  const { setSelectedCar, toggleReqService, toggleServices } = useAccountUIStore();
+
+  const memoizedCarFilterFn = useCallback(carFilterFn, []);
+  const { displayData: displayCars, handleSearch } = useFilteredData(
+    user?.cars,
+    memoizedCarFilterFn
+  );
+
+  const handleCar = (e) =>
+    handleCarActionUtil(e, user?.cars, setSelectedCar, { toggleReqService, toggleServices });
+
+  return { displayCars, handleSearch, handleCar };
+}


### PR DESCRIPTION
## Summary

Continuation of #112 — clears the last three JSX components that still contained business logic after the first pass.

## Hooks created

| Hook | Extracted from | What moved |
|---|---|---|
| `useContactLegacyForm` | `Contact.jsx` | `useState` formData + async `onSubmit` |
| `useAccountInit` | `Account.jsx` | `useEffect` — reactive fetch on `selectedCar` change |
| `useAccountTableData` | `AccountTable.jsx` | `useCallback`, `handleCar` handler, store selectors |

## Result

All JSX components in the codebase are now pure render wrappers — zero `useState`/`useEffect`/`useCallback` in any `.jsx` file except cases of genuine UI-only state (`expanded`, `hoveredService`, `isBlur`) and generic component internals (`Form`, `TableWithSort`).

## Test plan

- [ ] Account page loads cars table and services table correctly
- [ ] Selecting a car triggers services fetch
- [ ] Car action buttons (services / req-services) open correct modals
- [ ] Contact form submits without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)