### PR TITLE
fix: remove dead border:none from .cta-button base, add explicit border to .primary (closes #148)

### DIFF
--- a/client/src/components/landing/about/about.css
+++ b/client/src/components/landing/about/about.css
@@ -77,13 +77,13 @@
     border-radius: 0.5rem;
     font-size: 1.125rem;
     font-weight: 500;
-    border: none;
     cursor: pointer;
     transition: all 0.3s ease;
     text-decoration: none;
   }
-  
+
   .cta-button.primary {
+    border: 2px solid transparent;
     background-color: #2563eb;
     color: white;
   }


### PR DESCRIPTION
## What
Remove the dead `border: none` declaration from the `.cta-button` base class and add an explicit `border: 2px solid transparent` to `.cta-button.primary`. This makes both button variants self-contained — the base class no longer tries to pre-emptively reset a border that `.secondary` immediately overrides.

## Why
Closes #148

## Test plan
- [ ] Landing page renders correctly — primary (blue) and secondary (outlined) CTA buttons look identical to before
- [ ] No layout shift between the two button variants (both now have a 2px border, one transparent, one visible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)