### PR TITLE
fix: make ANTHROPIC_API_KEY optional (deploy was crashing at startup)

### DIFF
--- a/server/controllers/agent.js
+++ b/server/controllers/agent.js
@@ -1,6 +1,9 @@
 import Anthropic from "@anthropic-ai/sdk";
 
-const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+let client = null;
+if (process.env.ANTHROPIC_API_KEY) {
+  client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+}
 
 const SYSTEM_PROMPT = `אתה הסוכן החכם של Garage770 – מוסך שמנוהל באמצעות מערכת דיגיטלית.
 תפקידך לסייע לאנשי הצוות המנהלתי בשאלות לגבי:
@@ -15,6 +18,10 @@ const SYSTEM_PROMPT = `אתה הסוכן החכם של Garage770 – מוסך ש
 
 export const chat = async (req, res, next) => {
   try {
+    if (!client) {
+      return res.status(503).json({ error: "AI agent is not configured on this server" });
+    }
+
     const { message, history = [] } = req.body;
 
     if (!message?.trim()) {

--- a/server/index.js
+++ b/server/index.js
@@ -25,8 +25,7 @@ if (!process.env.JWT) {
 }
 
 if (!process.env.ANTHROPIC_API_KEY) {
-  console.error("FATAL: ANTHROPIC_API_KEY is not defined in environment variables");
-  process.exit(1);
+  console.warn("WARNING: ANTHROPIC_API_KEY is not set — /api/agent endpoints will be unavailable");
 }
 
 const app = express();


### PR DESCRIPTION
## Problem

PR #126 added a fatal startup check:
```js
if (!process.env.ANTHROPIC_API_KEY) {
  process.exit(1);  // ← crashed Render on every deploy
}
```

`ANTHROPIC_API_KEY` was not set as an environment variable on Render, so the server exited immediately and the deployment failed.

## Fix

`ANTHROPIC_API_KEY` is only needed for the `/api/agent/chat` endpoint. All other routes (appointments, cars, users, messages, etc.) are completely independent of it.

- **`index.js`**: downgrade to `console.warn` — server starts regardless
- **`controllers/agent.js`**: lazy-initialize the Anthropic client; if the key is absent, `/api/agent/chat` returns **503** with a clear message instead of crashing

## To re-enable the AI agent on Render

Add `ANTHROPIC_API_KEY` in your Render service → **Environment** tab. Once set, the agent will work without any code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)