### PR TITLE
fix: rename nav label from "Messages-Contact" to "Customer Messages" (closes #147)

### DIFF
--- a/client/src/components/nav/NavAdmin.jsx
+++ b/client/src/components/nav/NavAdmin.jsx
@@ -8,7 +8,7 @@ const NAV_LINKS = [
   { to: "/cars", label: "Cars" },
   { to: "/services", label: "Services" },
   { to: "/messages", label: "Messages" },
-  { to: "/messages-contact", label: "Messages-Contact" },
+  { to: "/messages-contact", label: "Customer Messages" },
   { to: "/appointments", label: "Appointments" },
 ];
 


### PR DESCRIPTION
## What
Replace the hyphenated internal route name `"Messages-Contact"` in the admin nav with the user-facing label `"Customer Messages"`. The `to` route path is unchanged.

## Why
Closes #147

## Test plan
- [ ] Admin nav shows "Customer Messages" instead of "Messages-Contact"
- [ ] Clicking the link still navigates to `/messages-contact`
- [ ] Visual rhythm of nav items is consistent (all single or short readable phrases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)