### PR TITLE
fix: add focus-visible outline to contact form inputs/textarea (closes #145)

### DIFF
--- a/client/src/components/landing/contact/newContact.css
+++ b/client/src/components/landing/contact/newContact.css
@@ -71,6 +71,11 @@
   border-color: #4a9eff;
 }
 
+.container-contact form input:focus-visible {
+  outline: 2px solid #4a9eff;
+  outline-offset: 2px;
+}
+
 .container-contact form input::placeholder {
   color: #ddd;
 }
@@ -94,6 +99,11 @@
 
 .container-contact form textarea:focus {
   border-color: #4a9eff;
+}
+
+.container-contact form textarea:focus-visible {
+  outline: 2px solid #4a9eff;
+  outline-offset: 2px;
 }
 
 /* Textarea Scrollbar */


### PR DESCRIPTION
## What
Add `focus-visible` outline rules for the contact form `input` and `textarea` elements. The `outline: none` reset is kept (prevents double ring in click scenarios), but keyboard navigation now renders a visible `2px solid #4a9eff` outline — matching the existing `border-color: #4a9eff` focus state already in the design.

## Why
Closes #145 — fixes WCAG 2.4.7 (Focus Visible) violation: keyboard users had no indicator of which contact form field was active.

## Test plan
- [ ] Tab through the contact form with keyboard — each field gets a visible blue outline ring
- [ ] Mouse clicks do not show the outline (only keyboard/non-pointer focus triggers `focus-visible`)
- [ ] Outline colour (#4a9eff) matches the existing focus border highlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)