### PR TITLE
fix: call useLoginForm at top level, fix Rules of Hooks violation (closes #138)

### DIFF
--- a/client/src/components/header/hooks/useHeaderHandlers.js
+++ b/client/src/components/header/hooks/useHeaderHandlers.js
@@ -5,11 +5,10 @@ import { useHeaderUIStore } from "../../../stores/uiStores";
 export const useHeaderHandlers = () => {
   const headerNav = useHeaderNav();
   const toggleLogin = useHeaderUIStore((s) => s.toggleLogin);
-
-  const useLogin = () => useLoginForm(toggleLogin);
+  const loginForm = useLoginForm(toggleLogin);
 
   return {
-    useLogin,
+    loginForm,
     isNavOpen: headerNav.isNavOpen,
     handleOutsideClick: headerNav.handleOutsideClick,
     handleLogin: headerNav.handleLogin,

--- a/client/src/components/login/Login.jsx
+++ b/client/src/components/login/Login.jsx
@@ -3,8 +3,8 @@ import { useHeaderUIStore } from "../../stores/uiStores";
 import { useHeaderHandlers } from "../header/hooks/useHeaderHandlers";
 const Login = () => {
   const isOpenLogin = useHeaderUIStore((s) => s.loginOpen);
-  const { useLogin, handleLogin } = useHeaderHandlers();
-  const { setFormData, onSubmit } = useLogin();
+  const { loginForm, handleLogin } = useHeaderHandlers();
+  const { setFormData, onSubmit } = loginForm;
   return (
     <OpenModal
       comp={


### PR DESCRIPTION
## What
- `useHeaderHandlers`: removed the inner `useLogin` closure that called `useLoginForm` inside a function. `useLoginForm(toggleLogin)` is now called unconditionally at the top level and returned as `loginForm`.
- `Login.jsx`: updated to destructure `loginForm` instead of calling `useLogin()`.

## Why
Closes #138 — `useLogin` was a function that internally called a hook, which is a React Rules of Hooks violation. Any conditional call of `useLogin()` would crash the component tree with "change in the order of Hooks called".

## Test plan
- [ ] Login modal opens and functions correctly
- [ ] Form submit / credential errors still work
- [ ] No console warnings about hook order

🤖 Generated with [Claude Code](https://claude.com/claude-code)