### PR TITLE
fix: add accessible labels to contact form inputs and textarea (closes #139, closes #140)

### DIFF
--- a/client/src/components/form/FormInput.jsx
+++ b/client/src/components/form/FormInput.jsx
@@ -41,7 +41,11 @@ export default function FormInput({
 
   return (
     <label className={classNameLabel}>
-      {!input.hidden && !classNameLabel && <span>{input.name}</span>}
+      {!input.hidden && (
+        <span className={classNameLabel ? "sr-only" : undefined}>
+          {input.placeholder || input.name}
+        </span>
+      )}
       {errorMessage && (
         <span id={`${input.name}-error`} className="error">
           {errorMessage}

--- a/client/src/components/landing/contact/NewContact.jsx
+++ b/client/src/components/landing/contact/NewContact.jsx
@@ -34,8 +34,8 @@ export default function NewContact() {
             <FormInput key={field.name} input={field} handleChange={handleChange} classNameLabel={" "} />
           ))}
         </div>
-        <h4>Type your message here...</h4>
-        <textarea name="message" required onChange={handleChange}></textarea>
+        <label htmlFor="contact-message" className="message-label">Message</label>
+        <textarea id="contact-message" name="message" placeholder="Type your message here..." required onChange={handleChange}></textarea>
         {submitError && <p className="error">{submitError}</p>}
         <div className="button-container">
           <button type="submit">Send</button>

--- a/client/src/components/landing/contact/newContact.css
+++ b/client/src/components/landing/contact/newContact.css
@@ -36,7 +36,8 @@
   font-size: clamp(24px, 5vw, 32px);
 }
 
-.container-contact form h4 {
+.container-contact .message-label {
+  display: block;
   color: #fff;
   font-weight: 300;
   width: 100%;


### PR DESCRIPTION
## What
**`FormInput.jsx`** (#140): The label `<span>` was only rendered when `classNameLabel` was falsy — but the default is `"form-label"` (always truthy), so the span was never shown and screen readers had no label. Fixed to always render the span; it gets `sr-only` when a label class is present, making it visually hidden but screen-reader-accessible.

**`NewContact.jsx` + `newContact.css`** (#139): The message textarea was preceded by an `<h4>` with no semantic connection to the field. Replaced with a `<label htmlFor="contact-message">` wired to `id="contact-message"` on the textarea. CSS selector updated from `h4` to `.message-label` — same visual styles.

## Why
Closes #139 — textarea had no bound label (WCAG 1.3.1 violation).
Closes #140 — FormInput labels were suppressed, losing field context for typing users (WCAG 3.3.2).

## Test plan
- [ ] Screen reader announces each contact form field name when focused
- [ ] "Message" label appears visually above the textarea (same style as before)
- [ ] Clicking the "Message" label focuses the textarea
- [ ] Other forms using `FormInput` (Login, Register, Edit User) are visually unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)