### PR TITLE
fix: correct populate field names, lower default limit, add CI test jobs (closes #157, #158, #159, #160)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,33 @@ jobs:
         working-directory: client
         env:
           VITE_API_URL: http://localhost:8800/api
+
+  server-test:
+    name: Server — unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install server dependencies
+        run: npm install
+        working-directory: server
+      - name: Run tests
+        run: npm test
+        working-directory: server
+
+  client-test:
+    name: Client — unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install client dependencies
+        run: npm install
+        working-directory: client
+      - name: Run tests
+        run: npm test
+        working-directory: client

--- a/server/services/dashboardService.js
+++ b/server/services/dashboardService.js
@@ -61,7 +61,7 @@ const getDashboardStats = async () => {
   const recentAppointments = await Appointment.find()
     .sort({ createdAt: -1 })
     .limit(10)
-    .populate("user", "name email");
+    .populate("user", "username email");
 
   // Get appointments by status
   const appointmentsByStatus = await Appointment.aggregate([
@@ -77,8 +77,8 @@ const getDashboardStats = async () => {
   const recentMessages = await Message.find()
     .sort({ createdAt: -1 })
     .limit(10)
-    .populate("from", "name email")
-    .populate("to", "name email");
+    .populate("from", "username email")
+    .populate("to", "username email");
 
   // Get monthly trends for the last 6 months
   const sixMonthsAgo = new Date();

--- a/server/services/messageService.js
+++ b/server/services/messageService.js
@@ -4,6 +4,7 @@ import { createError } from "../utils/error.js";
 import { getPaginationParams, pickAllowed } from "../utils/queryHelpers.js";
 
 const ALLOWED_MESSAGE_POPULATE_FIELDS = ['from', 'to'];
+const ALLOWED_MESSAGE_FIELDS = ['title', 'description'];
 
 const createMessage = async (req) => {
   const from = req.user.id; // always use authenticated user's ID, never trust URL param
@@ -19,7 +20,6 @@ const createMessage = async (req) => {
   });
   return savedMessage;
 };
-const ALLOWED_MESSAGE_FIELDS = ['title', 'description'];
 
 const createMessageToAdmin = async (req) => {
   const to = req.params.to;

--- a/server/utils/queryHelpers.js
+++ b/server/utils/queryHelpers.js
@@ -1,7 +1,8 @@
+const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 500;
 
 export const getPaginationParams = (req) => ({
-  limit: Math.min(parseInt(req.query.limit) || MAX_LIMIT, MAX_LIMIT),
+  limit: Math.min(parseInt(req.query.limit) || DEFAULT_LIMIT, MAX_LIMIT),
   page: Math.max(parseInt(req.query.page) || 1, 1),
 });
 


### PR DESCRIPTION
## What

Four single-file code-quality and bug fixes bundled together:

- **#157 (critical bug)** `dashboardService.js` — `populate("user"/"from"/"to", "name email")` → `"username email"`. The `User` schema field is `username`, so MongoDB was silently returning `null` and the dashboard Recent Appointments / Recent Messages widgets showed blank names.
- **#159 (low quality)** `messageService.js` — moved `ALLOWED_MESSAGE_FIELDS` declaration from after `createMessage` to before it (alongside `ALLOWED_MESSAGE_POPULATE_FIELDS`). Functionally identical today but no longer fragile if the function is ever moved to another module.
- **#160 (medium perf)** `queryHelpers.js` — added `DEFAULT_LIMIT = 50`; the fallback when no `?limit=` is sent is now 50 instead of 500. `MAX_LIMIT` remains 500 as the hard cap for explicit requests.
- **#158 (DX)** `ci.yml` — added `server-test` and `client-test` jobs so both `npm test` scripts run on every PR. Both scripts already exist and pass locally; they were simply never wired into CI.

## Why

Closes #157
Closes #158
Closes #159
Closes #160

## Test plan

- [ ] Dashboard page: Recent Appointments and Recent Messages widgets now show usernames instead of blank names
- [ ] `npm test` passes in both `client/` and `server/` locally
- [ ] CI runs all three jobs (lint+build, server-test, client-test) green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)