### PR TITLE
feat: add CSV export to all admin tables — contacts, users, cars, messages (closes #163)

### DIFF
--- a/client/src/pages/cars/CarsTable.jsx
+++ b/client/src/pages/cars/CarsTable.jsx
@@ -3,7 +3,7 @@ import Table from "../../components/table/Table";
 import { useCarsTableData } from "./hooks/useCarsTableData";
 
 export default function CarsTable() {
-  const { displayCars, handleSearch, handleCarAction } = useCarsTableData();
+  const { displayCars, handleSearch, handleCarAction, handleExport } = useCarsTableData();
 
   const trTh = (
     <tr>
@@ -36,7 +36,7 @@ export default function CarsTable() {
   ));
   return (
     <div className="table-container">
-      <Search handleSearch={handleSearch} name={"Cars"} />
+      <Search handleSearch={handleSearch} name={"Cars"} onExport={handleExport} />
       <Table trTh={trTh} trTd={trTd} />
     </div>
   );

--- a/client/src/pages/cars/hooks/useCarsTableData.js
+++ b/client/src/pages/cars/hooks/useCarsTableData.js
@@ -5,6 +5,7 @@ import { useCarsUIStore } from "../../../stores/uiStores";
 import { useCarAdminHandlers } from "./useCarAdminHandlers";
 import useFilteredData from "../../../hooks/useFilteredData";
 import { carFilterFn } from "../utils/carValidation";
+import { exportToCsv } from "../../../utils/exportCsv";
 
 export function useCarsTableData() {
   const user = useUserStore((s) => s.user);
@@ -25,5 +26,15 @@ export function useCarsTableData() {
     getCarsByType(user?._id);
   }, [manageCarOpen, deleteCarOpen, editCarOpen, getCarsByType, user?._id]);
 
-  return { displayCars, handleSearch, handleCarAction };
+  const handleExport = () => {
+    const rows = displayCars?.map((c) => ({
+      numberPlate: c.numberPlate,
+      brand: c.brand,
+      km: c.km,
+      owner: c.owner?.username || "",
+    }));
+    exportToCsv(rows, "cars");
+  };
+
+  return { displayCars, handleSearch, handleCarAction, handleExport };
 }

--- a/client/src/pages/messages/MessagesTable.jsx
+++ b/client/src/pages/messages/MessagesTable.jsx
@@ -4,7 +4,7 @@ import { getMomentFromUpdatedAt } from "../../utils";
 import { useMessagesTable } from "./hooks/useMessagesTable";
 
 export default function MessagesTable() {
-  const { displayMessages, handleSearch, handleMsgAction, toggleCreateMsg, user } =
+  const { displayMessages, handleSearch, handleMsgAction, toggleCreateMsg, user, handleExport } =
     useMessagesTable();
   const trTh = (
     <tr>
@@ -43,7 +43,7 @@ export default function MessagesTable() {
 
   return (
     <div className="table-container">
-      <Search handleSearch={handleSearch} name={"Messages"} />
+      <Search handleSearch={handleSearch} name={"Messages"} onExport={handleExport} />
       <Table trTh={trTh} trTd={trTd} />
       <button onClick={toggleCreateMsg} className="create-button">
         Create Message

--- a/client/src/pages/messages/hooks/useMessagesTable.js
+++ b/client/src/pages/messages/hooks/useMessagesTable.js
@@ -5,6 +5,7 @@ import { useMessagesUIStore } from "../../../stores/uiStores";
 import useFilteredData from "../../../hooks/useFilteredData";
 import { messageFilterFn } from "../utils/messageValidation";
 import { handleMessageAction as handleMessageActionUtil } from "../utils/messageHandlerUtils";
+import { exportToCsv } from "../../../utils/exportCsv";
 
 export function useMessagesTable() {
   const messages = useUserStore((s) => s.messages);
@@ -29,5 +30,15 @@ export function useMessagesTable() {
     handleMessageActionUtil(e, messages, setSelectedMsg, { toggleCreateMsg, toggleDeleteMsg });
   };
 
-  return { displayMessages, handleSearch, handleMsgAction, toggleCreateMsg, user };
+  const handleExport = () => {
+    const rows = displayMessages?.map((m) => ({
+      from: m.from?.username || "",
+      to: m.to?.username || "",
+      title: m.title,
+      description: m.description,
+    }));
+    exportToCsv(rows, "messages");
+  };
+
+  return { displayMessages, handleSearch, handleMsgAction, toggleCreateMsg, user, handleExport };
 }

--- a/client/src/pages/messagesOfContact/MsgOfContactTable.jsx
+++ b/client/src/pages/messagesOfContact/MsgOfContactTable.jsx
@@ -5,7 +5,7 @@ import { getMomentFromUpdatedAt } from "../../utils";
 import { useMsgOfContactTable } from "./hooks/useMsgOfContactTable";
 
 export default function MsgOfContactTable() {
-  const { displayContacts, handleSearch, handleContact } = useMsgOfContactTable();
+  const { displayContacts, handleSearch, handleContact, handleExport } = useMsgOfContactTable();
 
   const trTh = (
     <tr>
@@ -36,7 +36,7 @@ export default function MsgOfContactTable() {
 
   return (
     <div className="table-container">
-      <Search handleSearch={handleSearch} name={"Message of Contacts"} />
+      <Search handleSearch={handleSearch} name={"Message of Contacts"} onExport={handleExport} />
       <Table trTh={trTh} trTd={trTd} />
     </div>
   );

--- a/client/src/pages/messagesOfContact/hooks/useMsgOfContactTable.js
+++ b/client/src/pages/messagesOfContact/hooks/useMsgOfContactTable.js
@@ -3,6 +3,7 @@ import { useAdminStore } from "../../../stores/adminStore";
 import useFilteredData from "../../../hooks/useFilteredData";
 import { contactFilterFn } from "../utils/contactValidation";
 import { handleContactAction as handleContactActionUtil } from "../utils/contactHandlerUtils";
+import { exportToCsv } from "../../../utils/exportCsv";
 
 export function useMsgOfContactTable() {
   const messagesContact = useAdminStore((s) => s.messagesContact);
@@ -23,5 +24,16 @@ export function useMsgOfContactTable() {
     storeGetMessagesContact();
   };
 
-  return { displayContacts, handleSearch, handleContact };
+  const handleExport = () => {
+    const rows = displayContacts?.map((c) => ({
+      firstName: c.firstName,
+      lastName: c.lastName,
+      email: c.email,
+      phone: c.phone,
+      message: c.message,
+    }));
+    exportToCsv(rows, "contacts");
+  };
+
+  return { displayContacts, handleSearch, handleContact, handleExport };
 }

--- a/client/src/pages/users/UsersTable.jsx
+++ b/client/src/pages/users/UsersTable.jsx
@@ -3,7 +3,7 @@ import Table from "../../components/table/Table";
 import { useUsersTableData } from "./hooks/useUsersTableData";
 
 export default function UsersTable() {
-  const { displayUsers, handleSearch, handleUser, handleSortHeader, toggleCreateUser } =
+  const { displayUsers, handleSearch, handleUser, handleSortHeader, toggleCreateUser, handleExport } =
     useUsersTableData();
 
 
@@ -35,7 +35,7 @@ export default function UsersTable() {
   ));
   return (
     <div className="table-container">
-      <Search handleSearch={handleSearch} name={"Users"} />
+      <Search handleSearch={handleSearch} name={"Users"} onExport={handleExport} />
       <Table trTh={trTh} trTd={trTd} />
       <button onClick={toggleCreateUser} className="create-button">
         Create User

--- a/client/src/pages/users/hooks/useUsersTableData.js
+++ b/client/src/pages/users/hooks/useUsersTableData.js
@@ -4,6 +4,7 @@ import { useUsersUIStore } from "../../../stores/uiStores";
 import { useUserAdminHandlers } from "./useUserAdminHandlers";
 import useFilteredData from "../../../hooks/useFilteredData";
 import { userFilterFn } from "../utils/userValidation";
+import { exportToCsv } from "../../../utils/exportCsv";
 
 export function useUsersTableData() {
   const users = useAdminStore((s) => s.users);
@@ -36,5 +37,14 @@ export function useUsersTableData() {
     handleSort(key, direction);
   };
 
-  return { displayUsers, handleSearch, handleUser, handleSortHeader, toggleCreateUser };
+  const handleExport = () => {
+    const rows = displayUsers?.map((u) => ({
+      username: u.username,
+      email: u.email,
+      phone: u.phone,
+    }));
+    exportToCsv(rows, "users");
+  };
+
+  return { displayUsers, handleSearch, handleUser, handleSortHeader, toggleCreateUser, handleExport };
 }


### PR DESCRIPTION
## What

Wires the existing `exportToCsv` utility to the four admin tables that were missing an export button: **Contacts**, **Users**, **Cars**, and **Messages**.

The `exportToCsv(data, filename)` utility and the `Search` component's `onExport` prop were already fully implemented (Appointments and Services already used them). This PR completes the rollout by adding `handleExport` to each table's data hook and passing `onExport={handleExport}` to `Search`.

**Tables now with export:**

| Table | Exported columns |
|---|---|
| Contacts | firstName, lastName, email, phone, message |
| Users | username, email, phone |
| Cars | numberPlate, brand, km, owner |
| Messages | from, to, title, description |

The two already-working tables (Appointments, Services) are untouched.

## Why

Closes #163

## Test plan

- [ ] Open each admin table (Contacts, Users, Cars, Messages) — an "⬇ Export CSV" button appears in the search bar
- [ ] Clicking the button downloads a `.csv` file with the correct columns and data
- [ ] Empty tables: clicking export does nothing (no crash — `exportToCsv` guards for empty arrays)
- [ ] Appointments and Services export still works (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)