### PR TITLE
fix: server data-integrity and auth fixes (closes #188, #196, #198, #199, #200, #201)

### DIFF
--- a/server/models/Service.js
+++ b/server/models/Service.js
@@ -19,6 +19,7 @@ const ServiceSchema = new mongoose.Schema(
     price: {
       type: Number,
       required: true,
+      min: 0,
     },
     paid: {
       type: Boolean,
@@ -26,6 +27,7 @@ const ServiceSchema = new mongoose.Schema(
     },
     status: {
       type: String,
+      enum: ["pending", "in-progress", "done", "cancelled"],
       default: "pending",
       required: true,
     },

--- a/server/services/appointmentService.js
+++ b/server/services/appointmentService.js
@@ -59,7 +59,8 @@ const updateAppointmentStatus = async (req) => {
 };
 
 const deleteAppointment = async (req) => {
-  await Appointment.findByIdAndDelete(req.params.id);
+  const deleted = await Appointment.findByIdAndDelete(req.params.id);
+  if (!deleted) throw createError(404, "Appointment not found");
   return "Appointment has been deleted";
 };
 

--- a/server/services/contactService.js
+++ b/server/services/contactService.js
@@ -1,6 +1,7 @@
 import Contact from "../models/Contact.js";
 import { templatePhone } from "../utils/templates.js";
 import { getPaginationParams, pickAllowed } from "../utils/queryHelpers.js";
+import { createError } from "../utils/error.js";
 
 const ALLOWED_CONTACT_FIELDS = ['firstName', 'lastName', 'email', 'phone', 'message'];
 
@@ -22,7 +23,8 @@ const getContacts = async (req) => {
 };
 
 const deleteContact = async (req) => {
-  await Contact.findByIdAndDelete(req.params.id);
+  const deleted = await Contact.findByIdAndDelete(req.params.id);
+  if (!deleted) throw createError(404, "Contact not found");
   return "The Contact has been removed";
 };
 

--- a/server/services/serviceService.js
+++ b/server/services/serviceService.js
@@ -48,6 +48,7 @@ const updateService = async (req) => {
 const deleteService = async (req) => {
   const deleted = await Service.findByIdAndDelete(req.params.id);
   if (!deleted) throw createError(404, "Service not found");
+  await Car.findByIdAndUpdate(deleted.car, { $pull: { services: deleted._id } });
 };
 
 const getService = async (req) => {

--- a/server/utils/verifyToken.js
+++ b/server/utils/verifyToken.js
@@ -26,7 +26,8 @@ export const verifyUser = (req, res, next) => {
   verifyToken(req, res, (err) => {
     if (err) return next(err);
     
-    if (req.user.id === req.params.id || req.user.isAdmin) {
+    const routeUserId = req.params.id ?? req.params.user;
+    if (req.user.id === routeUserId || req.user.isAdmin) {
       return next();
     }
     


### PR DESCRIPTION
## What

Six server-side single-file fixes bundled together:

| Issue | File | Fix |
|---|---|---|
| **#188** | `appointmentService.js` | `deleteAppointment` now throws 404 when the ID doesn't exist (was silently returning 200) |
| **#196** | `Service.js` model | Added `enum: ['pending','in-progress','done','cancelled']` to `status` — arbitrary strings no longer accepted |
| **#201** | `Service.js` model | Added `min: 0` to `price` — negative prices now rejected at DB level |
| **#198** | `verifyToken.js` | `verifyUser` now accepts both `req.params.id` and `req.params.user` — fixes 403 for `/cars/user/:user` and `/services/user/:user` routes |
| **#199** | `serviceService.js` | `deleteService` now removes the service ID from `Car.services` via `$pull` after deletion |
| **#200** | `contactService.js` | `deleteContact` now throws 404 when contact not found; added `createError` import |

## Why

Closes #188, closes #196, closes #198, closes #199, closes #200, closes #201

## Test plan

- [ ] `DELETE /api/appointments/:nonexistent-id` → 404 (was 200)
- [ ] Updating a service status via direct API with an invalid value → Mongoose validation error
- [ ] Updating a service price to -1 → Mongoose validation error
- [ ] Regular user can access `GET /cars/user/:userId` (was 403)
- [ ] Deleting a service also removes it from the car's services array
- [ ] `DELETE /api/contacts/:nonexistent-id` → 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)