### PR TITLE
fix: 404 page — visible background, centered layout, home link (closes #184)

### DIFF
--- a/client/src/components/pageNotFound/PageNotFound.jsx
+++ b/client/src/components/pageNotFound/PageNotFound.jsx
@@ -1,9 +1,11 @@
+import { Link } from "react-router-dom";
 import "./pageNotFound.css";
 
 const PageNotFound = () => {
   return (
     <div className="not-found">
       <h1>404 - הדף לא נמצא</h1>
+      <Link to="/">חזור לדף הבית</Link>
     </div>
   );
 };

--- a/client/src/components/pageNotFound/pageNotFound.css
+++ b/client/src/components/pageNotFound/pageNotFound.css
@@ -1,5 +1,25 @@
 .not-found {
-    background-image: url("../../images/garage404.jpg");
-    background-repeat: no-repeat;
-    background-size:100%;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background-image: url("../../images/garage404.jpg");
+  background-repeat: no-repeat;
+  background-size: cover;
+  background-position: center;
+  text-align: center;
+  padding: 2rem;
+}
+
+.not-found h1 {
+  color: #e5e7eb;
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.8);
+  margin-bottom: 1.5rem;
+}
+
+.not-found a {
+  color: #4a9eff;
+  font-size: 1.1rem;
+  text-decoration: underline;
 }


### PR DESCRIPTION
## What

The 404 page had three issues — all fixed:

1. **Background invisible** — `.not-found` had no height, so the background image div was ~30px tall. Added `min-height: 100vh` + `background-size: cover` + `background-position: center`.
2. **No layout** — Added `display: flex; flex-direction: column; align-items: center; justify-content: center` to center content, plus `padding: 2rem`.
3. **No way home** — Added `<Link to="/">חזור לדף הבית</Link>` so users can recover from a 404.

Also added heading and link styles for legibility over the background image.

## Why

Closes #184

## Test plan

- [ ] Navigate to `/nonexistent-route` — background image fills the screen
- [ ] Heading is readable (white text with shadow)
- [ ] "חזור לדף הבית" link is visible and navigates to `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)