### PR TITLE
fix: add error handling to car/service/message/account action hooks (closes #189)

### DIFF
--- a/client/src/pages/account/hooks/useAccountActions.js
+++ b/client/src/pages/account/hooks/useAccountActions.js
@@ -1,5 +1,7 @@
 import { createReqService } from "../../../api/services/messageApi";
 
+const extractErrorMessage = (err) => err?.response?.data?.message ?? err?.message ?? String(err);
+
 /**
  * Custom hook for account service operations
  * @param {Object} selectedCar - Currently selected car
@@ -13,13 +15,17 @@ export const useAccountActions = (selectedCar, user) => {
    */
   const onSubmitReqService = async (e, formData, handleReqService) => {
     e.preventDefault();
-    const requestData = {
-      ...formData,
-      title: selectedCar?.numberPlate.toString(),
-      from: user?._id,
-    };
-    await createReqService(requestData);
-    handleReqService();
+    try {
+      const requestData = {
+        ...formData,
+        title: selectedCar?.numberPlate.toString(),
+        from: user?._id,
+      };
+      await createReqService(requestData);
+      handleReqService();
+    } catch (err) {
+      throw new Error(extractErrorMessage(err));
+    }
   };
 
   return {

--- a/client/src/pages/cars/hooks/useCarActions.js
+++ b/client/src/pages/cars/hooks/useCarActions.js
@@ -1,6 +1,8 @@
 import { updateCar, deleteCar } from "../../../api/services/carApi";
 import { createService } from "../../../api/services/serviceApi";
 
+const extractErrorMessage = (err) => err?.response?.data?.message ?? err?.message ?? String(err);
+
 /**
  * Custom hook for car CRUD operations
  * @param {Object} selectedCar - Currently selected car
@@ -14,8 +16,12 @@ export const useCarActions = (selectedCar, setFilteredCars) => {
    */
   const onSubmitCreateService = async (e, formData, handleCreateService) => {
     e.preventDefault();
-    await createService(selectedCar?._id, formData);
-    handleCreateService();
+    try {
+      await createService(selectedCar?._id, formData);
+      handleCreateService();
+    } catch (err) {
+      throw new Error(extractErrorMessage(err));
+    }
   };
 
   /**
@@ -23,8 +29,12 @@ export const useCarActions = (selectedCar, setFilteredCars) => {
    */
   const onSubmitEditCar = async (e, formData, handleEditCar) => {
     e.preventDefault();
-    await updateCar(selectedCar?._id, formData);
-    handleEditCar();
+    try {
+      await updateCar(selectedCar?._id, formData);
+      handleEditCar();
+    } catch (err) {
+      throw new Error(extractErrorMessage(err));
+    }
   };
 
   /**
@@ -34,11 +44,15 @@ export const useCarActions = (selectedCar, setFilteredCars) => {
     e.preventDefault();
     const { name } = e.target;
     if (name === "deleteCar") {
-      await deleteCar(selectedCar?._id, selectedCar?.owner._id.toString());
-      handleDeleteCar();
-      setFilteredCars((cars) =>
-        cars.filter((car) => car._id !== selectedCar._id)
-      );
+      try {
+        await deleteCar(selectedCar?._id, selectedCar?.owner._id.toString());
+        handleDeleteCar();
+        setFilteredCars((cars) =>
+          cars.filter((car) => car._id !== selectedCar._id)
+        );
+      } catch (err) {
+        throw new Error(extractErrorMessage(err));
+      }
     }
   };
 

--- a/client/src/pages/messages/hooks/useMessageActions.js
+++ b/client/src/pages/messages/hooks/useMessageActions.js
@@ -4,6 +4,8 @@ import {
   createMessageToAdmin,
 } from "../../../api/services/messageApi";
 
+const extractErrorMessage = (err) => err?.response?.data?.message ?? err?.message ?? String(err);
+
 /**
  * Custom hook for message CRUD operations
  * @param {Object} selectedMsg - Currently selected message
@@ -17,12 +19,16 @@ export const useMessageActions = (selectedMsg, user) => {
    */
   const onSubmitCreateMessage = async (e, formData, handleCreateMessage) => {
     e.preventDefault();
-    if (user?.isAdmin) {
-      await createMessage(formData, formData?.to);
-    } else {
-      await createMessageToAdmin(formData);
+    try {
+      if (user?.isAdmin) {
+        await createMessage(formData, formData?.to);
+      } else {
+        await createMessageToAdmin(formData);
+      }
+      handleCreateMessage();
+    } catch (err) {
+      throw new Error(extractErrorMessage(err));
     }
-    handleCreateMessage();
   };
 
   /**
@@ -32,8 +38,12 @@ export const useMessageActions = (selectedMsg, user) => {
     e.preventDefault();
     const { name } = e.target;
     if (name === "deleteMessage") {
-      await deleteMessage(selectedMsg?._id);
-      handleDeleteMessage();
+      try {
+        await deleteMessage(selectedMsg?._id);
+        handleDeleteMessage();
+      } catch (err) {
+        throw new Error(extractErrorMessage(err));
+      }
     }
   };
 

--- a/client/src/pages/servicesAdmin/hooks/useServiceActions.js
+++ b/client/src/pages/servicesAdmin/hooks/useServiceActions.js
@@ -1,5 +1,7 @@
 import { deleteService, updateService } from "../../../api/services/serviceApi";
 
+const extractErrorMessage = (err) => err?.response?.data?.message ?? err?.message ?? String(err);
+
 /**
  * Custom hook for service CRUD operations
  * @param {Object} selectedService - Currently selected service
@@ -12,17 +14,25 @@ export const useServiceActions = (selectedService) => {
    */
   const onSubmitEditService = async (e, formData, handleClick) => {
     e.preventDefault();
-    await updateService(selectedService?._id, formData);
-    handleClick();
-    // Data will be refreshed automatically by useEffect in ServiceAdminProvider
+    try {
+      await updateService(selectedService?._id, formData);
+      handleClick();
+      // Data will be refreshed automatically by useEffect in ServiceAdminProvider
+    } catch (err) {
+      throw new Error(extractErrorMessage(err));
+    }
   };
 
   /**
    * Delete a service
    */
   const onSubmitDeleteService = async (handleManageService) => {
-    await deleteService(selectedService?._id);
-    handleManageService();
+    try {
+      await deleteService(selectedService?._id);
+      handleManageService();
+    } catch (err) {
+      throw new Error(extractErrorMessage(err));
+    }
   };
 
   return {


### PR DESCRIPTION
## What

Four action hooks had no try/catch: `useCarActions`, `useServiceActions`, `useMessageActions`, and `useAccountActions`. When an API call threw (network error, 5xx), the error became an unhandled promise rejection with no user feedback.

Each async handler is now wrapped in try/catch. Errors are re-thrown as `new Error(extractErrorMessage(err))` so the caller (parent component) can display a message to the user.

**Hooks updated (one commit each pattern):**

| Hook | Handlers wrapped |
|---|---|
| `useCarActions` | `onSubmitCreateService`, `onSubmitEditCar`, `onSubmitDeleteCar` |
| `useServiceActions` | `onSubmitEditService`, `onSubmitDeleteService` |
| `useMessageActions` | `onSubmitCreateMessage`, `onSubmitDeleteMessage` |
| `useAccountActions` | `onSubmitReqService` |

## Why

Closes #189

## Test plan

- [ ] Simulate a network failure (DevTools → Offline) and try to delete a car — error should propagate (no silent success)
- [ ] Same for service edit, message creation, and service request
- [ ] Happy path for all four actions still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)