### PR TITLE
fix: client a11y + polish bundle (closes #171 #172 #173 #177 #178 #180 #181 #182)

### DIFF
--- a/client/src/api/services/messageApi.js
+++ b/client/src/api/services/messageApi.js
@@ -4,13 +4,9 @@ import { API_URL_MESSAGES } from "../apiEndpoints.js";
 
 const messageOps = createCrudOperations(API_URL_MESSAGES);
 
-let _cachedAdminId = null;
 const getAdminId = async () => {
-  if (!_cachedAdminId) {
-    const { data } = await axios.get("/auth/admin-id");
-    _cachedAdminId = data.adminId;
-  }
-  return _cachedAdminId;
+  const { data } = await axios.get("/auth/admin-id");
+  return data.adminId;
 };
 
 /**

--- a/client/src/components/landing/reviews/CreateReviews.jsx
+++ b/client/src/components/landing/reviews/CreateReviews.jsx
@@ -18,7 +18,7 @@ const CreateReviews = () => {
     <OpenModal
       comp={
         <form className="form">
-          <button onClick={handleAddReview} className="form-close">
+          <button type="button" onClick={handleAddReview} className="form-close">
             X
           </button>
           <h1>Garage review</h1>

--- a/client/src/components/landing/reviews/reviews.css
+++ b/client/src/components/landing/reviews/reviews.css
@@ -1,11 +1,11 @@
 :root {
   --review-primary: #5372f0;
-  --review-secondary: #dde4ff;
-  --review-text: #2d3748;
-  --review-text-light: #718096;
-  --review-border: #e2e8f0;
-  --review-shadow: rgba(0, 0, 0, 0.1);
-  --review-background: #ffffff;
+  --review-secondary: rgba(83, 114, 240, 0.2);
+  --review-text: #e5e7eb;
+  --review-text-light: #9ca3af;
+  --review-border: rgba(255, 255, 255, 0.1);
+  --review-shadow: rgba(0, 0, 0, 0.4);
+  --review-background: rgba(31, 41, 55, 0.8);
 }
 
 #reviews {

--- a/client/src/components/landing/reviews/starRating/StarRating.jsx
+++ b/client/src/components/landing/reviews/starRating/StarRating.jsx
@@ -13,6 +13,8 @@ const StarRating = (props) => {
           <button
             type="button"
             key={starValue}
+            aria-label={`${starValue} star${starValue > 1 ? "s" : ""}`}
+            aria-pressed={isActive(starValue)}
             className={`star-button ${isActive(starValue) ? "active" : ""} ${
               isDisabled ? "disabled" : ""
             }`}

--- a/client/src/components/landing/reviews/starRating/star-rating.css
+++ b/client/src/components/landing/reviews/starRating/star-rating.css
@@ -1,8 +1,6 @@
 .star-rating-container {
   display: inline-flex;
-  flex-direction: row-reverse;
   gap: 4px;
-  direction: rtl;
 }
 
 .star-button {

--- a/client/src/components/landing/reviews/swiper/NextCard.jsx
+++ b/client/src/components/landing/reviews/swiper/NextCard.jsx
@@ -6,7 +6,7 @@ export default function NextCard() {
   
   const {nextCard} = useReviewsContext()
   return (
-    <button onClick={nextCard} className="nav-button next-button">
+    <button onClick={nextCard} className="nav-button next-button" aria-label="Next review">
       ❯
     </button>
   );

--- a/client/src/components/landing/reviews/swiper/Prevcard.jsx
+++ b/client/src/components/landing/reviews/swiper/Prevcard.jsx
@@ -3,7 +3,7 @@ import { useReviewsState as useReviewsContext } from "../hooks/useReviewsState";
 export default function PrevCard (){
   const {prevCard} = useReviewsContext()
     return (
-      <button onClick={prevCard} className="nav-button prev-button">
+      <button onClick={prevCard} className="nav-button prev-button" aria-label="Previous review">
         ❮
       </button>
     );

--- a/client/src/pages/appointments/appointments.css
+++ b/client/src/pages/appointments/appointments.css
@@ -184,6 +184,14 @@
   border-bottom-color: #4a9eff;
 }
 
+.form-group input:focus-visible,
+.form-group textarea:focus-visible,
+.form-group select:focus-visible {
+  outline: 2px solid #4a9eff;
+  outline-offset: 3px;
+  border-radius: 2px;
+}
+
 .form-group select option {
   background-color: #1f2937;
   color: #e5e7eb;
@@ -543,6 +551,11 @@
   outline: none;
   border-color: #4a9eff;
   background: rgba(74, 158, 255, 0.06);
+}
+
+.apt-search-input:focus-visible {
+  outline: 2px solid #4a9eff;
+  outline-offset: 2px;
 }
 
 .apt-export-btn {

--- a/client/src/pages/appointments/components/AppointmentsList.jsx
+++ b/client/src/pages/appointments/components/AppointmentsList.jsx
@@ -69,6 +69,7 @@ const AppointmentsList = ({
               className={`action-status-btn action-${s} ${appointment.status === s ? "active-status" : ""}`}
               disabled={appointment.status === s}
               onClick={() => handleStatusChange(appointment._id, s)}
+              aria-pressed={appointment.status === s}
             >
               {capitalize(s)}
             </button>
@@ -87,6 +88,7 @@ const AppointmentsList = ({
             type="search"
             className="apt-search-input"
             placeholder="Search name, email, phone..."
+            aria-label="Search appointments by name, email, or phone"
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
           />
@@ -96,6 +98,7 @@ const AppointmentsList = ({
                 key={status}
                 className={`filter-btn ${filterStatus === status ? 'active' : ''}`}
                 onClick={() => setFilterStatus(status)}
+                aria-pressed={filterStatus === status}
               >
                 {capitalize(status)}
               </button>


### PR DESCRIPTION
## What

Eight single-file client fixes bundled — four accessibility improvements, one dark-theme fix, one stale-cache removal, and two HTML correctness fixes:

| # | File | Fix |
|---|---|---|
| **#173** | `CreateReviews.jsx` | Add `type="button"` to the × close button — was defaulting to `submit` and triggering a spurious API call on modal close |
| **#171** | `reviews.css` | Switch CSS custom-property values from the light palette (`#fff`, `#2d3748`) to dark glassmorphism values — review cards now match the landing page instead of appearing as white boxes |
| **#172** | `messageApi.js` | Remove stale `_cachedAdminId` module variable; `getAdminId` now always fetches fresh so messages can't silently route to a deleted admin account |
| **#177** | `StarRating.jsx` + `star-rating.css` | Add `aria-label` (e.g. "2 stars") and `aria-pressed` to each star button; remove `flex-direction:row-reverse` + `direction:rtl` from the container so visual order and DOM/tab order both run 1→5 |
| **#178** | `NextCard.jsx` + `Prevcard.jsx` | Add `aria-label="Next review"` / `"Previous review"` to carousel nav buttons |
| **#180** | `AppointmentsList.jsx` | Add `aria-label` to appointments search input |
| **#181** | `AppointmentsList.jsx` | Add `aria-pressed` to status filter buttons and per-appointment action buttons |
| **#182** | `appointments.css` | Add `:focus-visible` rules for form inputs and search box — restores keyboard focus rings that `outline:none` was removing |

## Why

Closes #171, closes #172, closes #173, closes #177, closes #178, closes #180, closes #181, closes #182

## Test plan

- [ ] Reviews section: cards render dark (glassmorphism) not white
- [ ] Review form: clicking × closes modal without network request
- [ ] Star rating: tabbing through stars goes 1→2→3→4→5; each star announces its value to screen reader
- [ ] Carousel: "Next review" / "Previous review" announced by screen reader
- [ ] Appointments: search input announced as "Search appointments by name, email, or phone"
- [ ] Appointments: filter buttons and status action buttons have `aria-pressed` that reflects current state
- [ ] Appointments: keyboard-focusing any form input shows a visible blue outline ring

🤖 Generated with [Claude Code](https://claude.com/claude-code)