### PR TITLE
fix: register request logger and fix admin list pagination (closes #170 #174)

### DIFF
--- a/client/src/api/crudOperations.js
+++ b/client/src/api/crudOperations.js
@@ -11,7 +11,7 @@ export const createCrudOperations = (baseUrl) => ({
    * Get all items
    */
   getAll: async () => {
-    const response = await axios.get(baseUrl);
+    const response = await axios.get(baseUrl, { params: { limit: 500 } });
     return response.data;
   },
   

--- a/server/app.js
+++ b/server/app.js
@@ -13,6 +13,7 @@ import appointmentsRoute from "./routes/appointments.js";
 import dashboardRoute from "./routes/dashboard.js";
 import agentRoute from "./routes/agent.js";
 import errorHandler from "./middleware/errorHandler.js";
+import { logger } from "./middleware/logger.js";
 
 const authLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
@@ -32,6 +33,7 @@ const publicLimiter = rateLimit({
 
 const app = express();
 
+app.use(logger);
 app.use(cookieParser());
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));


### PR DESCRIPTION
## What

Two single-file fixes bundled:

**#170 — `server/app.js`:** Import and register the `logger` Express middleware. When `index.js` was refactored into `app.js`, the logger was accidentally dropped. Without it, normal request traffic was never logged to `logs/reqLog.log` — only errors were captured by `errorHandler`.

**#174 — `client/src/api/crudOperations.js`:** Add `{ params: { limit: 500 } }` to `getAll`. The `DEFAULT_LIMIT=50` change (PR #165) capped all admin list endpoints at 50 records. Admin tables for users, cars, services, messages, and contacts silently stopped showing records 51+. Requesting `limit=500` (the server's `MAX_LIMIT`) restores the previous "show all" behaviour until pagination UI is added.

## Why

Closes #170, closes #174

## Test plan

- [ ] Start server — `logs/reqLog.log` should grow an entry for each request
- [ ] Admin → Users: should show more than 50 users when the dataset is larger
- [ ] Admin → Cars, Services, Messages: same — all records visible again

🤖 Generated with [Claude Code](https://claude.com/claude-code)