### PR TITLE
fix: validate name and description in review form before submit (closes #191)

### DIFF
--- a/client/src/components/landing/reviews/hooks/useReviewForm.js
+++ b/client/src/components/landing/reviews/hooks/useReviewForm.js
@@ -12,11 +12,20 @@ export const useReviewForm = (handleAddReview, onSubmitSuccess) => {
   const addReview = (e) => {
     e.preventDefault();
     setSubmitError(null);
-    setFormData({
-      name: nameRef.current.value,
-      description: descRef.current.value,
-      stars,
-    });
+
+    const name = nameRef.current.value.trim();
+    const description = descRef.current.value.trim();
+
+    if (!name) {
+      setSubmitError("Name is required.");
+      return;
+    }
+    if (!description) {
+      setSubmitError("Description is required.");
+      return;
+    }
+
+    setFormData({ name, description, stars });
     setIsSubmitted(true);
     handleAddReview();
     onSubmitSuccess?.();


### PR DESCRIPTION
## What

`useReviewForm.addReview` now validates that name and description are non-empty before calling `setFormData`. If either is blank, `submitError` is set (already rendered in `CreateReviews.jsx`) and the function returns early — the modal stays open so the user can correct the input, and no API call is fired.

Previously, blank submissions went through, the `useEffect` called `createReview` which returned a Mongoose `ValidationError`, but the modal had already been closed so the error was invisible to the user.

## Why

Closes #191

## Test plan

- [ ] Open review form, leave name blank, click submit — "Name is required." appears inside the modal (modal stays open)
- [ ] Fill name, leave description blank, click submit — "Description is required." appears
- [ ] Fill both fields, click submit — review posts successfully and modal closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)