### PR TITLE
fix: dashboard 60s TTL cache + OpenModal dialog semantics (closes #176 #169)

### DIFF
--- a/client/src/components/openModal/OpenModal.jsx
+++ b/client/src/components/openModal/OpenModal.jsx
@@ -1,19 +1,37 @@
 import "./openModal.css";
+import { useEffect } from "react";
 import PropTypes from "prop-types";
 
-const OpenModal = ({ comp = null, isOpen = false }) => {
+const OpenModal = ({ comp = null, isOpen = false, onClose }) => {
+  useEffect(() => {
+    if (!isOpen || !onClose) return;
+    const handleKeyDown = (e) => { if (e.key === "Escape") onClose(); };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
   return (
-    isOpen && (
-      <div className="open-modal-background">
-        <div className="open-modal-container">{comp} </div>
+    <div
+      className="open-modal-background"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose?.(); }}
+    >
+      <div
+        className="open-modal-container"
+        role="dialog"
+        aria-modal="true"
+      >
+        {comp}
       </div>
-    )
+    </div>
   );
 };
 
 OpenModal.propTypes = {
   comp: PropTypes.node,
   isOpen: PropTypes.bool,
+  onClose: PropTypes.func,
 };
 
 export default OpenModal;

--- a/server/services/dashboardService.js
+++ b/server/services/dashboardService.js
@@ -22,11 +22,17 @@ const getMonthlyTrend = (Model, since) =>
     { $sort: { "_id.year": 1, "_id.month": 1 } },
   ]);
 
+let _cache = { data: null, expiresAt: 0 };
+const CACHE_TTL_MS = 60_000; // 1 minute
+
 /**
  * Get comprehensive dashboard statistics
+ * Results are cached for 60 seconds to reduce DB load.
  * @returns {Object} Dashboard statistics including counts, recent data, and trends
  */
 const getDashboardStats = async () => {
+  if (_cache.data && Date.now() < _cache.expiresAt) return _cache.data;
+
   // Get total counts
   const [
     totalUsers,
@@ -121,7 +127,7 @@ const getDashboardStats = async () => {
     ? reviewStats[0].averageRating 
     : 0;
 
-  return {
+  const data = {
     overview: {
       totalUsers,
       totalCars,
@@ -147,6 +153,8 @@ const getDashboardStats = async () => {
     },
     topServices,
   };
+  _cache = { data, expiresAt: Date.now() + CACHE_TTL_MS };
+  return data;
 };
 
 export default {


### PR DESCRIPTION
## What

Two single-file fixes bundled:

**#176 — `server/services/dashboardService.js`**
Added a 60-second in-process TTL cache to `getDashboardStats`. The function previously fired 13+ DB round-trips on every dashboard visit. Now the first call computes and stores the result; subsequent calls within the TTL window return the cached object instantly. The cache is module-level, so it resets on server restart and never serves stale data across deploys.

**#169 — `client/src/components/openModal/OpenModal.jsx`**
- Added `role="dialog"` and `aria-modal="true"` to the inner container so screen readers announce modals correctly (was a plain `div` with no ARIA semantics).
- Added an optional `onClose` prop. When provided: pressing **Escape** or clicking the dark **backdrop** calls `onClose()` to close the modal.
- Existing callers that don't pass `onClose` are fully backward-compatible — the modal behaves exactly as before.

## Why

Closes #176, closes #169

## Test plan

- [ ] Open dashboard — first load hits DB; refresh within 60 s returns instantly
- [ ] Open any modal — screen reader announces "dialog"
- [ ] Pass `onClose` to a modal (e.g. Login) — pressing Escape closes it
- [ ] Click outside the modal content (backdrop) — modal closes
- [ ] Callers that don't pass `onClose` (e.g. ManageUser) — unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)