### PR TITLE
fix: backend security hardening — NoSQL injection, password leaks, user enumeration, agent rate limit

### DIFF
--- a/server/__tests__/auth.test.js
+++ b/server/__tests__/auth.test.js
@@ -55,22 +55,22 @@ describe("POST /api/auth/login", () => {
     assert.ok(!res.body.password, "should not expose password");
   });
 
-  it("returns 400 on wrong password", async () => {
+  it("returns 401 on wrong password", async () => {
     await makeUser({ username: "bob", password: "Correct99" });
 
     const res = await request(app)
       .post("/api/auth/login")
       .send({ username: "bob", password: "WrongPass1" });
 
-    assert.equal(res.status, 400);
+    assert.equal(res.status, 401);
   });
 
-  it("returns 404 when user does not exist", async () => {
+  it("returns 401 when user does not exist", async () => {
     const res = await request(app)
       .post("/api/auth/login")
       .send({ username: "nobody", password: "Password1" });
 
-    assert.equal(res.status, 404);
+    assert.equal(res.status, 401);
   });
 
   it("returns 400 when fields are missing", async () => {

--- a/server/app.js
+++ b/server/app.js
@@ -31,6 +31,14 @@ const publicLimiter = rateLimit({
   legacyHeaders: false,
 });
 
+const agentLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 10,
+  message: { message: "Too many AI requests, please try again later" },
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
 const app = express();
 
 app.use(logger);
@@ -51,7 +59,7 @@ app.use("/api/reviews", publicLimiter, reviewsRoute);
 app.use("/api/contacts", publicLimiter, contactsRoute);
 app.use("/api/appointments", publicLimiter, appointmentsRoute);
 app.use("/api/dashboard", dashboardRoute);
-app.use("/api/agent", agentRoute);
+app.use("/api/agent", agentLimiter, agentRoute);
 
 app.use((req, res) => {
   res.status(404).json({ message: "Route not found" });

--- a/server/controllers/agent.js
+++ b/server/controllers/agent.js
@@ -22,16 +22,20 @@ export const chat = async (req, res, next) => {
       return res.status(503).json({ error: "AI agent is not configured on this server" });
     }
 
-    const { message, history = [] } = req.body;
+    const { message, history } = req.body;
 
-    if (!message?.trim()) {
+    if (typeof message !== "string" || !message.trim()) {
       return res.status(400).json({ error: "Message is required" });
     }
+    if (message.length > 2000) {
+      return res.status(400).json({ error: "Message must be under 2000 characters" });
+    }
 
-    const conversationHistory = history
+    const rawHistory = Array.isArray(history) ? history : [];
+    const conversationHistory = rawHistory
       .filter((m) => m.role === "user" || m.role === "assistant")
       .slice(-10)
-      .map((m) => ({ role: m.role, content: m.content }));
+      .map((m) => ({ role: m.role, content: String(m.content ?? "").slice(0, 2000) }));
 
     conversationHistory.push({ role: "user", content: message });
 

--- a/server/services/appointmentService.js
+++ b/server/services/appointmentService.js
@@ -64,8 +64,13 @@ const deleteAppointment = async (req) => {
   return "Appointment has been deleted";
 };
 
+const VALID_STATUSES = ["pending", "confirmed", "cancelled"];
+
 const getAppointmentsByStatus = async (req) => {
   const { status } = req.query;
+  if (!status || !VALID_STATUSES.includes(status)) {
+    throw createError(400, `Status must be one of: ${VALID_STATUSES.join(", ")}`);
+  }
   const { limit, page } = getPaginationParams(req);
   const appointments = await Appointment.find({ status })
     .sort({ date: -1 })

--- a/server/services/authService.js
+++ b/server/services/authService.js
@@ -76,10 +76,10 @@ const login = async (req) => {
   }
 
   const user = await User.findOne({ username });
-  if (!user) throw createError(404, "User not found");
+  if (!user) throw createError(401, "Invalid credentials");
 
   const isPassword = await bcrypt.compare(password, user.password);
-  if (!isPassword) throw createError(400, "Wrong password");
+  if (!isPassword) throw createError(401, "Invalid credentials");
 
   const token = jwt.sign(
     { id: user._id, isAdmin: user.isAdmin },

--- a/server/services/messageService.js
+++ b/server/services/messageService.js
@@ -78,8 +78,8 @@ const getMessageByUser = async (req) => {
   const messages = await Message.find({
     $or: [{ to: req.params.id }, { from: req.params.id }],
   })
-    .populate("to")
-    .populate("from")
+    .populate("to", "-password")
+    .populate("from", "-password")
     .skip((page - 1) * limit)
     .limit(limit);
   return messages;
@@ -97,7 +97,7 @@ const getMessagesByType = async (req) => {
     throw createError(400, `Invalid populate field. Allowed: ${ALLOWED_MESSAGE_POPULATE_FIELDS.join(', ')}`);
   }
   const { limit, page } = getPaginationParams(req);
-  const messages = await Message.find().populate(type).skip((page - 1) * limit).limit(limit);
+  const messages = await Message.find().populate(type, "-password").skip((page - 1) * limit).limit(limit);
   return messages;
 };
 

--- a/server/services/serviceService.js
+++ b/server/services/serviceService.js
@@ -49,6 +49,7 @@ const deleteService = async (req) => {
   const deleted = await Service.findByIdAndDelete(req.params.id);
   if (!deleted) throw createError(404, "Service not found");
   await Car.findByIdAndUpdate(deleted.car, { $pull: { services: deleted._id } });
+  return "The Service has been removed";
 };
 
 const getService = async (req) => {

--- a/server/services/userService.js
+++ b/server/services/userService.js
@@ -95,7 +95,7 @@ const getUsersByType = async (req) => {
     throw createError(400, `Invalid populate field. Allowed: ${ALLOWED_POPULATE_FIELDS.join(', ')}`);
   }
   const { limit, page } = getPaginationParams(req);
-  const users = await User.find().populate(type).skip((page - 1) * limit).limit(limit);
+  const users = await User.find().select("-password").populate(type).skip((page - 1) * limit).limit(limit);
   return users;
 };
 


### PR DESCRIPTION
## Summary

- **NoSQL injection** (`appointmentService`): `?status[$gt]=` from query string was passed directly to `Appointment.find()`. Added a whitelist check that rejects any value not in `["pending","confirmed","cancelled"]` before the query runs.
- **Password exposure** (`userService`, `messageService`): `getUsersByType`, `getMessageByUser`, and `getMessagesByType` were calling `.populate()` without excluding the `password` field, leaking hashed passwords to clients (including regular users in the message case). Fixed with `.select("-password")` / `.populate(field, "-password")`.
- **User enumeration** (`authService`): Login returned distinct messages — `"User not found"` (404) vs `"Wrong password"` (400) — allowing username discovery. Both now return `401 "Invalid credentials"`.
- **Missing return in `deleteService`** (`serviceService`): The function had no `return` statement, causing `createHandler` to call `res.json(undefined)`, which sends an empty response body. Added `return "The Service has been removed"`.
- **Unprotected Anthropic API key** (`app.js`, `agent.js`): `/api/agent` had no rate limiter, and incoming `message`/`history` had no type or length validation. Added `agentLimiter` (10 req/min), capped `message` at 2000 chars, guarded `history` as an array, and capped each history item's content at 2000 chars.

## Files changed

| File | Change |
|------|--------|
| `server/services/appointmentService.js` | Whitelist-validate `status` query param |
| `server/services/userService.js` | `.select("-password")` on populate query |
| `server/services/messageService.js` | `.populate(field, "-password")` in two places |
| `server/services/serviceService.js` | Add missing `return` in `deleteService` |
| `server/services/authService.js` | Uniform `401 "Invalid credentials"` for login failures |
| `server/app.js` | Add `agentLimiter` (10 req/min) to `/api/agent` |
| `server/controllers/agent.js` | Validate + cap `message` length; guard `history` type |

## Test plan

- [ ] `GET /api/appointments/status?status[$gt]=` → 400, no documents returned
- [ ] `GET /api/users/populate?populate=cars` → user objects have no `password` field
- [ ] `GET /api/messages/user/:id` → populated `to`/`from` have no `password` field
- [ ] `DELETE /api/services/:id` → response body is `"The Service has been removed"` (not empty)
- [ ] Login with wrong username → `401 "Invalid credentials"` (same as wrong password)
- [ ] POST `/api/agent/chat` 11 times in 1 min → 11th returns 429
- [ ] POST `/api/agent/chat` with `message` > 2000 chars → 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)