### PR TITLE
fix: rate-limit admin routes, drop dead :from param, enforce km floor (closes #227 #229 #234)

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -51,14 +51,14 @@ app.use(cors({
 }));
 
 app.use("/api/auth", authLimiter, authRoute);
-app.use("/api/users", usersRoute);
-app.use("/api/cars", carsRoute);
-app.use("/api/services", servicesRoute);
+app.use("/api/users", publicLimiter, usersRoute);
+app.use("/api/cars", publicLimiter, carsRoute);
+app.use("/api/services", publicLimiter, servicesRoute);
 app.use("/api/messages", publicLimiter, messagesRoute);
 app.use("/api/reviews", publicLimiter, reviewsRoute);
 app.use("/api/contacts", publicLimiter, contactsRoute);
 app.use("/api/appointments", publicLimiter, appointmentsRoute);
-app.use("/api/dashboard", dashboardRoute);
+app.use("/api/dashboard", publicLimiter, dashboardRoute);
 app.use("/api/agent", agentLimiter, agentRoute);
 
 app.use((req, res) => {

--- a/server/routes/messages.js
+++ b/server/routes/messages.js
@@ -31,7 +31,7 @@ authRouter.post("/to/:to", createMessageToAdmin);
 authRouter.put("/:id", updateMessage);
 authRouter.delete("/:id", deleteMessage);
 authRouter.get("/:id", getMessage);
-authRouter.post("/:from/:to", createMessage);
+authRouter.post("/:to", createMessage);
 
 router.use(adminRouter);
 router.use(userRouter);

--- a/server/services/carService.js
+++ b/server/services/carService.js
@@ -29,6 +29,13 @@ const updateCar = async (req) => {
   if (safeBody.numberPlate) {
     safeBody.numberPlate = templateCar(safeBody.numberPlate);
   }
+  if (safeBody.km !== undefined) {
+    const existing = await Car.findById(req.params.id).select("km");
+    if (!existing) throw createError(404, "Car not found");
+    if (safeBody.km < existing.km) {
+      throw createError(400, `km cannot be decreased (current: ${existing.km})`);
+    }
+  }
   const updatedCar = await Car.findByIdAndUpdate(
     req.params.id,
     { $set: safeBody },


### PR DESCRIPTION
## What

Three single-file server fixes bundled:

| # | File | Fix |
|---|---|---|
| **#227** | `app.js` | Apply `publicLimiter` (50 req/15 min) to `/api/users`, `/api/cars`, `/api/services`, and `/api/dashboard` — all four were completely unprotected |
| **#234** | `routes/messages.js` | Remove dead `:from` URL param from `POST /:from/:to`; the service always reads `from` from `req.user.id` (JWT), not from the URL. Simplified to `POST /:to` |
| **#229** | `services/carService.js` | In `updateCar`, fetch the existing `km` before writing; reject with 400 if the new value is lower — prevents odometer reversal via direct API calls that bypass the browser `min` constraint |

## Why

Closes #227, closes #229, closes #234

## Test plan

- [ ] Hit `/api/users` or `/api/cars` 51 times in 15 min — expect 429 on the 51st
- [ ] `POST /api/messages/to/:toId` still works (the `/to/:to` route is unaffected)
- [ ] `PUT /api/cars/:id` with `km` lower than current → 400 "km cannot be decreased"
- [ ] `PUT /api/cars/:id` with equal or higher `km` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)