### PR TITLE
fix: Delete dialog — type=button, cancel color, grammar (closes #212 #213 #215 #216)

### DIFF
--- a/client/src/components/delete/Delete.jsx
+++ b/client/src/components/delete/Delete.jsx
@@ -7,11 +7,12 @@ const Delete = ({deleteData,handle,nameData,isOpen,handleDelete}) => {
       comp={
         <>
           <form className="form">
-            <button onClick={handle} className="form-close">
+            <button type="button" onClick={handle} className="form-close">
               X
             </button>
             <h1 className="header">Delete</h1>
-            <h2>{`Are you sure to delete? : ${deleteData}`}</h2>
+            <h2>Delete <strong>{deleteData}</strong>?</h2>
+            <p className="delete-warning">⚠ This action cannot be undone.</p>
             <label className="form-label">
               <button
                 type="button"
@@ -19,12 +20,12 @@ const Delete = ({deleteData,handle,nameData,isOpen,handleDelete}) => {
                 className="delete"
                 onClick={handleDelete}
               >
-                Yes
+                Yes, delete
               </button>
             </label>
             <label className="form-label">
-              <button type="button" name="noDelete" className="create" onClick={handle}>
-                No
+              <button type="button" name="noDelete" className="cancel" onClick={handle}>
+                Cancel
               </button>
             </label>
           </form>

--- a/client/src/components/manage/FormManage.jsx
+++ b/client/src/components/manage/FormManage.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 export default function FormManage({ children, handle }) {
   return (
     <form className="form">
-      <button onClick={handle} className="form-close">
+      <button type="button" onClick={handle} className="form-close">
         X
       </button>
       <h1 className="header">Manage Admin</h1>

--- a/client/src/components/manage/manage.css
+++ b/client/src/components/manage/manage.css
@@ -50,10 +50,29 @@
   box-shadow: 0 4px 12px rgba(239, 68, 68, 0.3);
 }
 
+.cancel {
+  background: rgba(107, 114, 128, 0.3);
+  border-color: rgba(107, 114, 128, 0.4);
+}
+
+.cancel:hover {
+  background: rgba(107, 114, 128, 0.5);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(107, 114, 128, 0.2);
+}
+
+.delete-warning {
+  color: #fca5a5;
+  font-size: 0.85rem;
+  margin: -0.5rem 0 0.5rem;
+  text-align: center;
+}
+
 @media (max-width: 480px) {
   .create,
   .edit,
-  .delete {
+  .delete,
+  .cancel {
     height: 44px;
     font-size: 0.95rem;
   }


### PR DESCRIPTION
## What

Four fixes to the shared `Delete` and `FormManage` components, all in three files:

| # | File | Fix |
|---|---|---|
| **#212** | `FormManage.jsx` | Add `type="button"` to the × close button — was submitting the manage form on every close click |
| **#213** | `Delete.jsx` | Add `type="button"` to the × close button — same bug, same form-submit side-effect |
| **#215** | `Delete.jsx` + `manage.css` | Change "No" button class from `create` (green) to `cancel` (neutral gray). Added `.cancel` + hover rules to manage.css — green cancel next to red delete was visually dangerous/safe reversed |
| **#216** | `Delete.jsx` | Fix grammar: "Are you sure to delete? : X" → "Delete **X**?"; add "⚠ This action cannot be undone." warning; relabel "Yes" → "Yes, delete" and "No" → "Cancel" |

## Why

Closes #212, closes #213, closes #215, closes #216

## Test plan

- [ ] Click × on any Manage modal — dialog closes without a network request
- [ ] Click × on any Delete dialog — dialog closes without a network request
- [ ] Open Delete dialog — Cancel button is gray, delete button is red
- [ ] Confirmation text reads "Delete **username**?" with the warning below
- [ ] Clicking "Cancel" closes without deleting

🤖 Generated with [Claude Code](https://claude.com/claude-code)