### PR TITLE
fix: client a11y + UX bundle (closes #218 #219 #221 #231 #232 #233)

### DIFF
--- a/client/src/components/agent/Agent.jsx
+++ b/client/src/components/agent/Agent.jsx
@@ -125,7 +125,7 @@ export default function Agent() {
         aria-label={isOpen ? "סגור סוכן" : "פתח סוכן AI"}
       >
         {isOpen ? <CloseIcon /> : <BotIcon />}
-        {hasUnread && !isOpen && <span className="agent-fab-badge" />}
+        {hasUnread && !isOpen && <span className="agent-fab-badge" aria-label="הודעה חדשה מהסוכן" role="status" />}
       </button>
     </>
   );

--- a/client/src/components/header/hooks/useHeaderInit.js
+++ b/client/src/components/header/hooks/useHeaderInit.js
@@ -4,12 +4,11 @@ import { useUserStore } from "../../../stores/userStore";
 
 export function useHeaderInit() {
   const userAuth = useAuthStore((s) => s.user);
-  const user = useUserStore((s) => s.user);
   const getUser = useUserStore((s) => s.getUser);
 
   useEffect(() => {
-    if (userAuth?._id && !user) {
+    if (userAuth?._id) {
       getUser(userAuth._id);
     }
-  }, [userAuth, user, getUser]);
+  }, [userAuth?._id, getUser]);
 }

--- a/client/src/components/manage/ButtonManage.jsx
+++ b/client/src/components/manage/ButtonManage.jsx
@@ -2,11 +2,11 @@ import PropTypes from "prop-types";
 
 export default function ButtonManage({ handle, value, type, name, content }) {
   return (
-    <label className="form-label">
+    <div className="form-label">
       <button name={name} className={type} onClick={handle} value={value}>
         {content}
       </button>
-    </label>
+    </div>
   );
 }
 

--- a/client/src/components/openModal/OpenModal.jsx
+++ b/client/src/components/openModal/OpenModal.jsx
@@ -2,7 +2,7 @@ import "./openModal.css";
 import { useEffect } from "react";
 import PropTypes from "prop-types";
 
-const OpenModal = ({ comp = null, isOpen = false, onClose }) => {
+const OpenModal = ({ comp = null, isOpen = false, onClose, dialogTitle }) => {
   useEffect(() => {
     if (!isOpen || !onClose) return;
     const handleKeyDown = (e) => { if (e.key === "Escape") onClose(); };
@@ -21,6 +21,7 @@ const OpenModal = ({ comp = null, isOpen = false, onClose }) => {
         className="open-modal-container"
         role="dialog"
         aria-modal="true"
+        aria-label={dialogTitle || undefined}
       >
         {comp}
       </div>
@@ -32,6 +33,7 @@ OpenModal.propTypes = {
   comp: PropTypes.node,
   isOpen: PropTypes.bool,
   onClose: PropTypes.func,
+  dialogTitle: PropTypes.string,
 };
 
 export default OpenModal;

--- a/client/src/hooks/useFilteredData.js
+++ b/client/src/hooks/useFilteredData.js
@@ -9,7 +9,9 @@ import { useState, useCallback } from "react";
 const useFilteredData = (data, filterFn) => {
   const [filteredData, setFilteredData] = useState(null);
 
-  const displayData = filteredData || data;
+  const displayData = filteredData
+    ? filteredData.filter((item) => data?.some((d) => d._id === item._id))
+    : data;
 
   const handleSearch = useCallback(
     (e) => {

--- a/client/src/pages/account/AccountTable.jsx
+++ b/client/src/pages/account/AccountTable.jsx
@@ -6,10 +6,10 @@ export default function AccountTable() {
   const { displayCars, handleSearch, handleCar } = useAccountTableData();
   const trTh = (
     <tr>
-      <th>brand</th>
-      <th>numberPlate</th>
-      <th>km</th>
-      <th>history service</th>
+      <th>Brand</th>
+      <th>License Plate</th>
+      <th>Mileage (km)</th>
+      <th>Service History</th>
       <th>Request Service</th>
     </tr>
   );
@@ -21,12 +21,12 @@ export default function AccountTable() {
         <td>{car.km}</td>
         <td>
           <button value={car._id} name="services" onClick={handleCar}>
-            services
+            View Services
           </button>
         </td>
         <td>
           <button value={car._id} name="req-services" onClick={handleCar}>
-            req services
+            Request Service
           </button>
         </td>
       </tr>


### PR DESCRIPTION
## What

Six single-file client fixes bundled:

| # | File | Fix |
|---|---|---|
| **#218** | `ButtonManage.jsx` | Replace `<label>` wrapper with `<div>` — wrapping a button in `<label>` is invalid HTML; screen readers announced it twice |
| **#219** | `AccountTable.jsx` | Fix column headers: `brand→Brand`, `numberPlate→License Plate`, `km→Mileage (km)`, `history service→Service History`. Fix button labels: `services→View Services`, `req services→Request Service` |
| **#221** | `Agent.jsx` | Add `aria-label="הודעה חדשה מהסוכן"` and `role="status"` to the unread notification badge — was an empty `<span>` invisible to screen readers |
| **#231** | `useHeaderInit.js` | Remove `!user` guard so `getUser` is always called when `userAuth._id` is known; ensures fresh profile data after admin edits own account. Remove now-unused `user` selector |
| **#232** | `useFilteredData.js` | Compute `displayData` as the intersection of `filteredData` and `data` — deleted items no longer remain visible in search results after deletion |
| **#233** | `OpenModal.jsx` | Add optional `dialogTitle` prop; when provided it is set as `aria-label` on the `role="dialog"` container, giving the dialog an accessible name |

## Why

Closes #218, closes #219, closes #221, closes #231, closes #232, closes #233

## Test plan

- [ ] Open any Manage modal — screen reader does not double-announce buttons
- [ ] Account → My Cars — column headers show "Brand", "License Plate", "Mileage (km)", "Service History"; buttons show "View Services", "Request Service"
- [ ] Agent sends a message — screen reader announces the new-message badge
- [ ] Admin edits own profile — header username updates without reload
- [ ] Delete a user while search filter active — deleted user disappears immediately from results
- [ ] Callers that pass `dialogTitle` to `OpenModal` get `aria-label` on the dialog; existing callers unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)