### PR TITLE
fix: message recipient validation, dashboard loading state, account back nav (closes #228 #230 #220)

### DIFF
--- a/client/src/pages/account/AccountTables.jsx
+++ b/client/src/pages/account/AccountTables.jsx
@@ -1,7 +1,23 @@
 import AccountTable from "./AccountTable";
 import AccountServices from "./AccountServices";
 import { useAccountUIStore } from "../../stores/uiStores";
+
 export default function AccountTables() {
   const servicesOpen = useAccountUIStore((s) => s.servicesOpen);
-  return <>{servicesOpen ? <AccountServices /> : <AccountTable />}</>;
+  const toggleServices = useAccountUIStore((s) => s.toggleServices);
+
+  return (
+    <>
+      {servicesOpen && (
+        <button
+          className="back-btn"
+          onClick={toggleServices}
+          aria-label="Back to My Cars"
+        >
+          ← Back to My Cars
+        </button>
+      )}
+      {servicesOpen ? <AccountServices /> : <AccountTable />}
+    </>
+  );
 }

--- a/client/src/pages/account/account.css
+++ b/client/src/pages/account/account.css
@@ -2,3 +2,23 @@ tbody button:hover{
     border-radius: 4px;
     color:gray;
 }
+
+.back-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-bottom: 0.75rem;
+  padding: 0.4rem 1rem;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 6px;
+  color: #9ca3af;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+.back-btn:hover {
+  color: #e5e7eb;
+  border-color: rgba(255, 255, 255, 0.5);
+}

--- a/client/src/pages/dashboard/Dashboard.css
+++ b/client/src/pages/dashboard/Dashboard.css
@@ -558,3 +558,15 @@
     grid-template-columns: 1fr;
   }
 }
+
+.dashboard-loading,
+.dashboard-error {
+  text-align: center;
+  padding: 4rem 2rem;
+  font-size: 1.1rem;
+  color: #9ca3af;
+}
+
+.dashboard-error {
+  color: #f87171;
+}

--- a/client/src/pages/dashboard/Dashboard.jsx
+++ b/client/src/pages/dashboard/Dashboard.jsx
@@ -10,22 +10,34 @@ import {
 import "./Dashboard.css";
 
 const Dashboard = () => {
-  const { stats } = useDashboardData();
+  const { stats, isLoading, isError, message } = useDashboardData();
+
+  if (isLoading) {
+    return <div className="dashboard-loading">⏳ Loading dashboard…</div>;
+  }
+
+  if (isError) {
+    return (
+      <div className="dashboard-error">
+        ⚠️ Failed to load dashboard: {message || "Unknown error"}
+      </div>
+    );
+  }
+
+  if (!stats?.overview) return null;
 
   return (
-    stats?.overview && (
-      <div className="dashboard-container">
-        <div className="dashboard-header">
-          <h1 className="dashboard-title">Dashboard</h1>
-        </div>
-        <StatsOverview />
-        <AppointmentsByStatus />
-        <TopServices />
-        <RecentAppointments />
-        <RecentMessages />
-        <MonthlyTrends />
+    <div className="dashboard-container">
+      <div className="dashboard-header">
+        <h1 className="dashboard-title">Dashboard</h1>
       </div>
-    )
+      <StatsOverview />
+      <AppointmentsByStatus />
+      <TopServices />
+      <RecentAppointments />
+      <RecentMessages />
+      <MonthlyTrends />
+    </div>
   );
 };
 

--- a/client/src/pages/dashboard/hooks/useDashboardData.js
+++ b/client/src/pages/dashboard/hooks/useDashboardData.js
@@ -3,11 +3,14 @@ import { useDashboardStore } from "../../../stores/dashboardStore";
 
 export function useDashboardData() {
   const stats = useDashboardStore((s) => s.stats);
+  const isLoading = useDashboardStore((s) => s.isLoading);
+  const isError = useDashboardStore((s) => s.isError);
+  const message = useDashboardStore((s) => s.message);
   const getDashboardStats = useDashboardStore((s) => s.getDashboardStats);
 
   useEffect(() => {
     getDashboardStats();
   }, [getDashboardStats]);
 
-  return { stats };
+  return { stats, isLoading, isError, message };
 }

--- a/client/src/pages/messages/hooks/useMessageActions.js
+++ b/client/src/pages/messages/hooks/useMessageActions.js
@@ -19,9 +19,12 @@ export const useMessageActions = (selectedMsg, user) => {
    */
   const onSubmitCreateMessage = async (e, formData, handleCreateMessage) => {
     e.preventDefault();
+    if (user?.isAdmin && !formData?.to) {
+      throw new Error("Please select a recipient.");
+    }
     try {
       if (user?.isAdmin) {
-        await createMessage(formData, formData?.to);
+        await createMessage(formData, formData.to);
       } else {
         await createMessageToAdmin(formData);
       }


### PR DESCRIPTION
## What

Three multi-file fixes:

**#228 — `useMessageActions.js`**
Admin create-message now validates that `formData.to` is set before calling the API. Without this check, submitting the form without selecting a recipient called `POST /to/undefined`, returning a server error with no user feedback.

**#230 — `Dashboard.jsx` + `useDashboardData.js` + `Dashboard.css`**
The dashboard previously rendered `null` both while loading and on error. Now:
- During fetch → "⏳ Loading dashboard…" centered on the page
- On error → "⚠️ Failed to load dashboard: <message>" in red
- On success → existing dashboard layout unchanged

**#220 — `AccountTables.jsx` + `account.css`**
Added a "← Back to My Cars" button above `AccountServices`. When a user clicks "View Services" on a car row, the services view opens — but there was no way to return to the cars list without reloading. The back button calls the existing `toggleServices` action from the UI store.

## Why

Closes #228, closes #230, closes #220

## Test plan

- [ ] Admin creates message without selecting recipient → "Please select a recipient." error, no network request
- [ ] Navigate to Dashboard → see loading spinner briefly, then stats
- [ ] Take Dashboard offline (DevTools) → see error message, no blank page
- [ ] Account → click "View Services" on a car → "← Back to My Cars" button appears above service table
- [ ] Click "← Back to My Cars" → returns to cars table

🤖 Generated with [Claude Code](https://claude.com/claude-code)