### PR TITLE
fix: reviews carousel + message delete a11y (closes #217 #238 #239 #240 #241 #242)

### DIFF
--- a/client/src/components/landing/reviews/CreateReviews.jsx
+++ b/client/src/components/landing/reviews/CreateReviews.jsx
@@ -33,6 +33,7 @@ const CreateReviews = () => {
               type="text"
               title="Name"
               placeholder="type your name.."
+              maxLength={50}
             />
           </label>
           <label className="form-label">

--- a/client/src/components/landing/reviews/hooks/useReviewsData.js
+++ b/client/src/components/landing/reviews/hooks/useReviewsData.js
@@ -4,14 +4,19 @@ import { getReviews } from "../../../../api/services/reviewApi";
 // Refetch only when a review is submitted, not on every modal open/close
 export const useReviewsData = (isSubmitted) => {
   const [allReviews, setAllReviews] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isError, setIsError] = useState(false);
 
   useEffect(() => {
+    setIsLoading(true);
+    setIsError(false);
     getReviews()
       .then((data) => setAllReviews(data || []))
-      .catch(() => setAllReviews([]));
+      .catch(() => setIsError(true))
+      .finally(() => setIsLoading(false));
   }, [isSubmitted]);
 
   const totalCards = Array.isArray(allReviews) ? allReviews.length : 0;
 
-  return { allReviews, totalCards };
+  return { allReviews, totalCards, isLoading, isError };
 };

--- a/client/src/components/landing/reviews/swiper/hooks/useCardsNavigation.jsx
+++ b/client/src/components/landing/reviews/swiper/hooks/useCardsNavigation.jsx
@@ -1,21 +1,22 @@
 import { useState } from "react";
 
 
-export default function useCardsNavigation(numCardsPreview,totalCards) {
+export default function useCardsNavigation(numCardsPreview, totalCards) {
   const [currentIndex, setCurrentIndex] = useState(0);
+
+  if (!totalCards || !numCardsPreview) {
+    return { currentIndex: 0, nextCard: () => {}, prevCard: () => {}, indexPagination: () => {} };
+  }
+
+  const lastPageStart = Math.floor((totalCards - 1) / numCardsPreview) * numCardsPreview;
+
   // Handle navigation to next set of cards
   const nextCard = () => {
-    setCurrentIndex((prev) => (prev + numCardsPreview) % totalCards);
+    setCurrentIndex((prev) => (prev >= lastPageStart ? 0 : prev + numCardsPreview));
   };
 
   const prevCard = () => {
-    setCurrentIndex((prev) => {
-      const newIndex = prev - numCardsPreview;
-      return newIndex < 0
-        ? Math.floor((totalCards- 1) / numCardsPreview) *
-            numCardsPreview
-        : newIndex;
-    });
+    setCurrentIndex((prev) => (prev === 0 ? lastPageStart : prev - numCardsPreview));
   };
 
   // Handle pagination dot click
@@ -23,5 +24,5 @@ export default function useCardsNavigation(numCardsPreview,totalCards) {
     setCurrentIndex(index * numCardsPreview);
   };
 
-  return {currentIndex,nextCard,prevCard,indexPagination};
+  return { currentIndex, nextCard, prevCard, indexPagination };
 }

--- a/client/src/pages/messages/MessagesTable.jsx
+++ b/client/src/pages/messages/MessagesTable.jsx
@@ -27,6 +27,7 @@ export default function MessagesTable() {
               name="deleteMessage"
               value={message?._id}
               onClick={handleMsgAction}
+              aria-label={`Delete message from ${message?.from?.username || "unknown"}`}
             >
               Delete
             </button>

--- a/server/services/reviewService.js
+++ b/server/services/reviewService.js
@@ -12,7 +12,7 @@ const createReview = async (req) => {
 
 const getReviews = async (req) => {
   const { limit, page } = getPaginationParams(req);
-  const reviews = await Review.find().skip((page - 1) * limit).limit(limit);
+  const reviews = await Review.find().sort({ createdAt: -1 }).skip((page - 1) * limit).limit(limit);
   return reviews;
 };
 


### PR DESCRIPTION
## What

Six single-file fixes across the reviews carousel and messages table:

| # | File | Fix |
|---|---|---|
| **#239** | `reviewService.js` | Add `.sort({ createdAt: -1 })` — newest reviews now appear first in the carousel instead of always last |
| **#238** | `useCardsNavigation.jsx` | Fix `nextCard` wrap-around: `(prev + numCardsPreview) % totalCards` lands mid-page when `totalCards` is not a multiple of `numCardsPreview`; now explicitly wraps to 0 when past the last page |
| **#240** | `useCardsNavigation.jsx` | Guard against `totalCards=0` or `numCardsPreview=0` — returns no-op handlers to prevent `NaN` currentIndex on empty carousel |
| **#241** | `useReviewsData.js` | Add `isLoading` and `isError` state; fetch errors no longer silently fall back to `[]` — callers can now distinguish "no reviews yet" from "API failed" |
| **#242** | `CreateReviews.jsx` | Add `maxLength={50}` to the name input — was unbounded, allowing names that overflow the review card layout |
| **#217** | `MessagesTable.jsx` | Add `aria-label="Delete message from <username>"` to each delete button — was "Delete, Delete, Delete…" with no per-row context for screen readers |

## Why

Closes #217, closes #238, closes #239, closes #240, closes #241, closes #242

## Test plan

- [ ] Reviews carousel: newest review appears first
- [ ] Carousel with any number of reviews: Next button always wraps cleanly back to the first page
- [ ] Empty carousel (no reviews): no JavaScript error, no NaN index
- [ ] Messages admin table: screen reader announces "Delete message from alice" etc.
- [ ] Review name field: cannot type more than 50 characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)