### PR TITLE
fix: ViewReviews success screen — use shared isSubmittedTemp from context (closes #237)

### DIFF
--- a/client/src/components/landing/reviews/ViewReviews.jsx
+++ b/client/src/components/landing/reviews/ViewReviews.jsx
@@ -5,17 +5,16 @@ import Submitted from "../../Submitted";
 import { useReviewsState as useReviewsContext } from "./hooks/useReviewsState";
 
 export default function ViewReviews() {
-  const { useAddReview } = useReviewsContext();
-  const { isSubmitted, setIsSubmitted } = useAddReview();
+  const { isSubmittedTemp, setIsSubmittedTemp } = useReviewsContext();
 
   useEffect(() => {
-    if (!isSubmitted) return;
-    const id = setTimeout(() => setIsSubmitted(false), 7000);
+    if (!isSubmittedTemp) return;
+    const id = setTimeout(() => setIsSubmittedTemp(false), 7000);
     return () => clearTimeout(id);
-  }, [isSubmitted, setIsSubmitted]);
+  }, [isSubmittedTemp, setIsSubmittedTemp]);
 
-  if (isSubmitted) {
-    return <Submitted setIsSubmitted={setIsSubmitted} review={true} name={"review"} text={"Thank you for your review!"} />;
+  if (isSubmittedTemp) {
+    return <Submitted setIsSubmitted={setIsSubmittedTemp} review={true} name={"review"} text={"Thank you for your review!"} />;
   }
 
   return (

--- a/client/src/components/landing/reviews/hooks/useReviewsHandlers.js
+++ b/client/src/components/landing/reviews/hooks/useReviewsHandlers.js
@@ -37,6 +37,8 @@ export const useReviewsHandlers = (modals) => {
 
   return {
     useAddReview,
+    isSubmittedTemp,
+    setIsSubmittedTemp,
     indexPagination,
     prevCard,
     nextCard,

--- a/client/src/components/landing/reviews/hooks/useReviewsState.js
+++ b/client/src/components/landing/reviews/hooks/useReviewsState.js
@@ -12,6 +12,8 @@ export const useReviewsState = () => {
 
   return {
     useAddReview: reviewsHandlers.useAddReview,
+    isSubmittedTemp: reviewsHandlers.isSubmittedTemp,
+    setIsSubmittedTemp: reviewsHandlers.setIsSubmittedTemp,
     handleAddReview: toggleAddReview,
     isOpenAddReview: addReviewOpen,
     indexPagination: reviewsHandlers.indexPagination,


### PR DESCRIPTION
## What

`ViewReviews` and `CreateReviews` both called `useAddReview()` which creates a **new `useReviewForm` instance** each time. The two instances have completely independent `isSubmitted` state:

- `CreateReviews`' instance: `addReview` sets `isSubmitted = true` on submit
- `ViewReviews`' instance: reads its own `isSubmitted` which is always `false` → success screen never shown

**Root cause:** `isSubmitted` lived inside the hook instance, not in shared state.

**Fix:** `useReviewsHandlers` already had a shared `isSubmittedTemp` state (used to trigger review refetch). The `onSubmitSuccess` callback already calls `setIsSubmittedTemp(true)`. This fix:

1. **`useReviewsHandlers.js`** — expose `isSubmittedTemp` and `setIsSubmittedTemp` in the return object
2. **`useReviewsState.js`** — pass them through from handlers to the shared context
3. **`ViewReviews.jsx`** — read `isSubmittedTemp`/`setIsSubmittedTemp` from context instead of calling `useAddReview()` for a separate instance

`CreateReviews` is untouched — it still calls `useAddReview()` to get `addReview`, `nameRef`, `descRef`, and `submitError`.

## Why

Closes #237

## Test plan

- [ ] Submit a review — the "Thank you for your review!" screen appears after the modal closes
- [ ] Success screen auto-dismisses after 7 seconds
- [ ] Review modal still opens and submits correctly (no regression)
- [ ] Reviews carousel refetches after submission (still triggered by same `isSubmittedTemp`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)