### PR TITLE
fix: Agent.css direction:rtl — remove container RTL, add dir=auto per message (closes #224)

### DIFF
--- a/client/src/components/agent/Agent.css
+++ b/client/src/components/agent/Agent.css
@@ -169,7 +169,6 @@
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  direction: rtl;
   scroll-behavior: smooth;
 }
 

--- a/client/src/components/agent/Agent.jsx
+++ b/client/src/components/agent/Agent.jsx
@@ -22,7 +22,7 @@ const Message = ({ msg }) => {
         </div>
       )}
       <div className={`agent-bubble agent-bubble--${isBot ? "bot" : "user"}`}>
-        <p>{msg.content}</p>
+        <p dir="auto">{msg.content}</p>
         <span className="agent-time">{time}</span>
       </div>
     </div>


### PR DESCRIPTION
## What

`.agent-messages` had `direction: rtl` on the entire container, forcing all chat content — including English text — to render right-aligned in RTL layout. Mixed Hebrew/English conversations looked visually broken.

Two-line fix:
1. **`Agent.css`** — remove `direction: rtl` from `.agent-messages`
2. **`Agent.jsx`** — add `dir="auto"` to the message `<p>` element

`dir="auto"` lets the browser detect each message's directionality from its first strong-directional character: Hebrew content auto-aligns right, English content auto-aligns left.

## Why

Closes #224

## Test plan

- [ ] Send a Hebrew message — text aligns right ✓
- [ ] Send an English message — text aligns left ✓
- [ ] Bot responses in Hebrew — align right ✓
- [ ] Mixed conversation — each bubble aligns independently ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)