### PR TITLE
fix: frontend review pass 3 — modal close, useCallback cleanup, semantic HTML

### DIFF
--- a/client/src/components/common/ModalForm.jsx
+++ b/client/src/components/common/ModalForm.jsx
@@ -22,6 +22,7 @@ const ModalForm = ({
   return (
     <OpenModal
       isOpen={isOpen}
+      onClose={onClose}
       comp={
         <Form
           setData={setFormData}

--- a/client/src/components/delete/Delete.jsx
+++ b/client/src/components/delete/Delete.jsx
@@ -13,25 +13,22 @@ const Delete = ({deleteData,handle,nameData,isOpen,handleDelete}) => {
             <h1 className="header">Delete</h1>
             <h2>Delete <strong>{deleteData}</strong>?</h2>
             <p className="delete-warning">⚠ This action cannot be undone.</p>
-            <label className="form-label">
-              <button
-                type="button"
-                name={nameData}
-                className="delete"
-                onClick={handleDelete}
-              >
-                Yes, delete
-              </button>
-            </label>
-            <label className="form-label">
-              <button type="button" name="noDelete" className="cancel" onClick={handle}>
-                Cancel
-              </button>
-            </label>
+            <button
+              type="button"
+              name={nameData}
+              className="delete form-label"
+              onClick={handleDelete}
+            >
+              Yes, delete
+            </button>
+            <button type="button" name="noDelete" className="cancel form-label" onClick={handle}>
+              Cancel
+            </button>
           </form>
         </>
       }
       isOpen={isOpen}
+      onClose={handle}
     />
   );
 };

--- a/client/src/components/landing/reviews/CreateReviews.jsx
+++ b/client/src/components/landing/reviews/CreateReviews.jsx
@@ -58,6 +58,7 @@ const CreateReviews = () => {
         </form>
       }
       isOpen={isOpenAddReview}
+      onClose={handleAddReview}
     />
   );
 };

--- a/client/src/components/manage/ManageCar.jsx
+++ b/client/src/components/manage/ManageCar.jsx
@@ -39,6 +39,7 @@ const ManageCar = () => {
         </>
       }
       isOpen={manageCarOpen}
+      onClose={toggleManageCar}
     />
   );
 };

--- a/client/src/components/manage/ManageService.jsx
+++ b/client/src/components/manage/ManageService.jsx
@@ -37,6 +37,7 @@ const ManageService = () => {
         </>
       }
       isOpen={manageServiceOpen}
+      onClose={toggleManageService}
     />
   );
 };

--- a/client/src/components/manage/ManageUser.jsx
+++ b/client/src/components/manage/ManageUser.jsx
@@ -37,6 +37,7 @@ const ManageUser = () => {
         </>
       }
       isOpen={manageUserOpen}
+      onClose={toggleManageUser}
     />
   );
 };

--- a/client/src/pages/account/AccountServices.jsx
+++ b/client/src/pages/account/AccountServices.jsx
@@ -1,4 +1,3 @@
-import { useCallback } from "react";
 import Search from "../../components/table/Search";
 import Table from "../../components/table/Table";
 import { useAccountUIStore } from "../../stores/uiStores";
@@ -8,8 +7,7 @@ import { serviceFilterFn } from "./utils/accountValidation";
 export default function AccountServices() {
   const selectedCar = useAccountUIStore((s) => s.selectedCar);
   const services = useUserStore((s) => s.services);
-  const memoizedServiceFilterFn = useCallback(serviceFilterFn, []);
-  const { displayData: displayServicesUser, handleSearch: handleSerchServicesUser } = useFilteredData(services, memoizedServiceFilterFn);
+  const { displayData: displayServicesUser, handleSearch: handleSerchServicesUser } = useFilteredData(services, serviceFilterFn);
   const trTh = (
     <tr>
       <th>title</th>

--- a/client/src/pages/account/hooks/useAccountTableData.js
+++ b/client/src/pages/account/hooks/useAccountTableData.js
@@ -1,4 +1,3 @@
-import { useCallback } from "react";
 import { useUserStore } from "../../../stores/userStore";
 import { useAccountUIStore } from "../../../stores/uiStores";
 import useFilteredData from "../../../hooks/useFilteredData";
@@ -9,10 +8,9 @@ export function useAccountTableData() {
   const user = useUserStore((s) => s.user);
   const { setSelectedCar, toggleReqService, toggleServices } = useAccountUIStore();
 
-  const memoizedCarFilterFn = useCallback(carFilterFn, []);
   const { displayData: displayCars, handleSearch } = useFilteredData(
     user?.cars,
-    memoizedCarFilterFn
+    carFilterFn
   );
 
   const handleCar = (e) =>

--- a/client/src/pages/cars/hooks/useCarsTableData.js
+++ b/client/src/pages/cars/hooks/useCarsTableData.js
@@ -1,4 +1,4 @@
-import { useEffect, useCallback } from "react";
+import { useEffect } from "react";
 import { useAdminStore } from "../../../stores/adminStore";
 import { useUserStore } from "../../../stores/userStore";
 import { useCarsUIStore } from "../../../stores/uiStores";
@@ -13,12 +13,11 @@ export function useCarsTableData() {
   const getCarsByType = useAdminStore((s) => s.getCarsByType);
   const { manageCarOpen, deleteCarOpen, editCarOpen } = useCarsUIStore();
 
-  const memoizedCarFilterFn = useCallback(carFilterFn, []);
   const {
     displayData: displayCars,
     handleSearch,
     setFilteredData: setFilteredCars,
-  } = useFilteredData(cars, memoizedCarFilterFn);
+  } = useFilteredData(cars, carFilterFn);
 
   const { handleCar: handleCarAction } = useCarAdminHandlers(setFilteredCars);
 

--- a/client/src/pages/messages/hooks/useMessagesTable.js
+++ b/client/src/pages/messages/hooks/useMessagesTable.js
@@ -1,4 +1,4 @@
-import { useEffect, useCallback } from "react";
+import { useEffect } from "react";
 import { useUserStore } from "../../../stores/userStore";
 import { useAdminStore } from "../../../stores/adminStore";
 import { useMessagesUIStore } from "../../../stores/uiStores";
@@ -15,10 +15,9 @@ export function useMessagesTable() {
   const { createMsgOpen, deleteMsgOpen, toggleCreateMsg, setSelectedMsg, toggleDeleteMsg } =
     useMessagesUIStore();
 
-  const memoizedFilterFn = useCallback(messageFilterFn, []);
   const { displayData: displayMessages, handleSearch } = useFilteredData(
     messages,
-    memoizedFilterFn
+    messageFilterFn
   );
 
   useEffect(() => {

--- a/client/src/pages/messagesOfContact/hooks/useMsgOfContactTable.js
+++ b/client/src/pages/messagesOfContact/hooks/useMsgOfContactTable.js
@@ -1,4 +1,4 @@
-import { useEffect, useCallback } from "react";
+import { useEffect } from "react";
 import { useAdminStore } from "../../../stores/adminStore";
 import useFilteredData from "../../../hooks/useFilteredData";
 import { contactFilterFn } from "../utils/contactValidation";
@@ -9,10 +9,9 @@ export function useMsgOfContactTable() {
   const messagesContact = useAdminStore((s) => s.messagesContact);
   const storeGetMessagesContact = useAdminStore((s) => s.getMessagesContact);
 
-  const memoizedContactFilterFn = useCallback(contactFilterFn, []);
   const { displayData: displayContacts, handleSearch } = useFilteredData(
     messagesContact,
-    memoizedContactFilterFn
+    contactFilterFn
   );
 
   useEffect(() => {

--- a/client/src/pages/servicesAdmin/hooks/useServiceAdminTableData.js
+++ b/client/src/pages/servicesAdmin/hooks/useServiceAdminTableData.js
@@ -1,4 +1,4 @@
-import { useEffect, useCallback } from "react";
+import { useEffect } from "react";
 import { useAdminStore } from "../../../stores/adminStore";
 import { useServicesUIStore } from "../../../stores/uiStores";
 import { useServiceAdminHandlers } from "./useServiceAdminHandlers";
@@ -13,10 +13,9 @@ export function useServiceAdminTableData() {
     useServicesUIStore();
   const { handleServiceIdAction } = useServiceAdminHandlers();
 
-  const memoizedServiceFilterFn = useCallback(serviceFilterFn, []);
   const { displayData: displayServices, handleSearch } = useFilteredData(
     services,
-    memoizedServiceFilterFn
+    serviceFilterFn
   );
 
   useEffect(() => {

--- a/client/src/pages/users/hooks/useUsersTableData.js
+++ b/client/src/pages/users/hooks/useUsersTableData.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect } from "react";
 import { useAdminStore } from "../../../stores/adminStore";
 import { useUsersUIStore } from "../../../stores/uiStores";
 import { useUserAdminHandlers } from "./useUserAdminHandlers";
@@ -12,13 +12,12 @@ export function useUsersTableData() {
   const { manageUserOpen, editUserOpen, deleteUserOpen, createUserOpen, toggleCreateUser } =
     useUsersUIStore();
 
-  const memoizedUserFilterFn = useCallback(userFilterFn, []);
   const {
     displayData: displayUsers,
     handleSearch,
     setFilteredData: setFilteredUsers,
     handleSort,
-  } = useFilteredData(users, memoizedUserFilterFn);
+  } = useFilteredData(users, userFilterFn);
 
   const { handleUser } = useUserAdminHandlers(setFilteredUsers);
 


### PR DESCRIPTION
## Summary

- **🟡 OpenModal `onClose` missing (6 components)** — `ModalForm`, `ManageUser`, `ManageCar`, `ManageService`, `Delete`, `CreateReviews` all rendered `<OpenModal>` without passing `onClose`. This meant clicking the backdrop and pressing Escape did nothing on every modal in the app. One-line fix per file.
- **🟢 `useCallback(stableFn, [])` × 7** — `carFilterFn`, `userFilterFn`, `serviceFilterFn`, `messageFilterFn`, `contactFilterFn` are module-level constants. Wrapping them in `useCallback` with an empty dep array adds overhead with zero benefit. Removed the wrappers and the now-unused `useCallback` imports.
- **🟢 `Delete.jsx` semantic HTML** — "Yes, delete" and "Cancel" buttons were wrapped in `<label>` elements. Labels are for form inputs; moved `form-label` class directly onto the buttons.

## Test plan

- [ ] Open any edit/create form (e.g. Edit User, Create Car) → press Escape → modal should close
- [ ] Open any edit/create form → click the dark backdrop → modal should close
- [ ] Open a Manage modal (User / Car / Service) → press Escape → modal should close
- [ ] Open a Delete confirmation modal → press Escape → modal should close
- [ ] Open the Add Review modal → press Escape → modal should close
- [ ] Confirm all table search inputs still filter correctly (Users, Cars, Services, Messages, Contacts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)