### PR TITLE
fix: backend data integrity — getUser 404, deleteUser cascade, message recipient guard

### DIFF
--- a/server/middleware/logger.js
+++ b/server/middleware/logger.js
@@ -25,6 +25,5 @@ export const logEvents = async (message, logFileName) => {
 
 export const logger = (req, res, next) => {
   logEvents(`${req?.method}\t${req?.url}\t${req?.headers.origin}`, "reqLog.log");
-  console.log(`${req?.method} ${req?.path}`);
   next();
 };

--- a/server/services/messageService.js
+++ b/server/services/messageService.js
@@ -9,6 +9,8 @@ const ALLOWED_MESSAGE_FIELDS = ['title', 'description'];
 const createMessage = async (req) => {
   const from = req.user.id; // always use authenticated user's ID, never trust URL param
   const to = req.params.to;
+  const recipientExists = await User.exists({ _id: to });
+  if (!recipientExists) throw createError(404, "Recipient not found");
   const safeBody = pickAllowed(req.body, ALLOWED_MESSAGE_FIELDS);
   const newMessage = new Message({ ...safeBody, to, from });
   const savedMessage = await newMessage.save();
@@ -23,6 +25,8 @@ const createMessage = async (req) => {
 
 const createMessageToAdmin = async (req) => {
   const to = req.params.to;
+  const recipientExists = await User.exists({ _id: to });
+  if (!recipientExists) throw createError(404, "Recipient not found");
   const safeBody = pickAllowed(req.body, ALLOWED_MESSAGE_FIELDS);
   const newMessage = new Message({ ...safeBody, to, from: req.user.id });
   const savedMessage = await newMessage.save();

--- a/server/services/userService.js
+++ b/server/services/userService.js
@@ -1,6 +1,7 @@
 import User from "../models/User.js";
 import Car from "../models/Car.js";
 import Message from "../models/Message.js";
+import Service from "../models/Service.js";
 import bcrypt from "bcryptjs";
 import { templatePhone } from "../utils/templates.js";
 import { createError } from "../utils/error.js";
@@ -70,16 +71,20 @@ const updateUser = async (req) => {
 
 const deleteUser = async (req) => {
   const { id } = req.params;
+  const cars = await Car.find({ owner: id }).select("_id").lean();
+  const carIds = cars.map((c) => c._id);
   await Promise.all([
     User.findByIdAndDelete(id),
     Car.deleteMany({ owner: id }),
     Message.deleteMany({ $or: [{ from: id }, { to: id }] }),
+    ...(carIds.length ? [Service.deleteMany({ car: { $in: carIds } })] : []),
   ]);
   return "the user has been removed";
 };
 
 const getUser = async (req) => {
   const user = await User.findById(req.params.id).select("-password").populate("cars");
+  if (!user) throw createError(404, "User not found");
   return user;
 };
 


### PR DESCRIPTION
## Summary

- **`getUser` silent null** (`userService`): `findById` returning `null` was passed through `createHandler` as `200 null`. Added a `404 "User not found"` guard so the client gets the correct error.
- **`deleteUser` orphaned services** (`userService`): Deleting a user removed their cars via `Car.deleteMany` but left all linked `Service` documents pointing at deleted cars. Fixed by collecting `carIds` before the parallel delete and adding `Service.deleteMany({ car: { $in: carIds } })` to the same `Promise.all`.
- **Dangling message recipient** (`messageService`): Both `createMessage` and `createMessageToAdmin` accepted any `to` ID without checking if the recipient exists. The message was saved with a stale reference and the `User.$push` silently did nothing. Added `User.exists({ _id: to })` guard → `404 "Recipient not found"` before saving.
- **Request-level `console.log`** (`middleware/logger`): Every request was logged to stdout — redundant since it's already written to `reqLog.log`. Removed the `console.log` line.

## Files changed

| File | Change |
|------|--------|
| `server/services/userService.js` | 404 guard in `getUser`; Service cascade in `deleteUser`; import `Service` |
| `server/services/messageService.js` | `User.exists` recipient guard in `createMessage` and `createMessageToAdmin` |
| `server/middleware/logger.js` | Remove `console.log` per-request line |

## Test plan

- [ ] `GET /api/users/:nonExistentId` → `404 "User not found"` (not `200 null`)
- [ ] Delete a user who has cars with services → confirm services are removed from DB
- [ ] `POST /api/messages/to/:fakeId` with valid token → `404 "Recipient not found"`
- [ ] Server stdout no longer logs every request path

🤖 Generated with [Claude Code](https://claude.com/claude-code)