### PR TITLE
fix: Suspense boundary for lazy routes + 401 redirect on JWT expiry (closes #257 #259)

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,4 +1,4 @@
-import { lazy } from "react";
+import { lazy, Suspense } from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { Header, Agent } from "./components";
 import PageNotFound from "./components/pageNotFound/PageNotFound";
@@ -34,6 +34,7 @@ function App() {
         <a href="#main-content" className="skip-link">Skip to content</a>
         <Header />
         <main id="main-content">
+        <Suspense fallback={<div className="page-loader" />}>
         <Routes>
           <Route path="/" element={<PageLanding />} />
           {PRIVATE_ROUTES.map(({ path, Component }) => (
@@ -50,6 +51,7 @@ function App() {
           <Route path="/unauthorized" element={<Unauthorized />} />
           <Route path="*" element={<PageNotFound />} />
         </Routes>
+        </Suspense>
         </main>
       </BrowserRouter>
       <Agent />

--- a/client/src/axiosConfig.js
+++ b/client/src/axiosConfig.js
@@ -11,6 +11,7 @@ axios.interceptors.response.use(
     if (error.response?.status === 401) {
       // clearAuth avoids an API call so this interceptor cannot loop
       useAuthStore.getState().clearAuth();
+      window.location.replace("/");
     }
     return Promise.reject(error);
   }


### PR DESCRIPTION
## What

Two single-file client fixes:

**#257 — `App.jsx`**
All 9 routes are loaded with `lazy()` but had no `<Suspense>` wrapper around the `<Routes>` block. When React renders a lazy route for the first time it suspends — without a boundary the `ErrorBoundary` catches the suspension as a crash, showing the error screen instead of a loading indicator. Added `<Suspense fallback={<div className="page-loader" />}>` around `<Routes>`.

**#259 — `axiosConfig.js`**
The 401 interceptor already existed and called `clearAuth()`, but did not redirect the user away from the broken page. Added `window.location.replace("/")` after clearing auth so users land back on the landing page (which shows the login modal) instead of seeing empty/broken admin views with no explanation.

## Why

Closes #257, closes #259

## Test plan

- [ ] Navigate to any private route for the first time — loading indicator shows briefly, then content renders (no error boundary crash)
- [ ] Log in, wait 24 h for JWT to expire (or manually expire it via DevTools), then trigger any API call — user is redirected to `/` and must log in again

🤖 Generated with [Claude Code](https://claude.com/claude-code)