### PR TITLE
fix: move hardcoded CORS origin and cookie domain to env vars (closes #258)

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -8,7 +8,12 @@ MONGO=mongodb+srv://<user>:<password>@<cluster>/<database>
 ANTHROPIC_API_KEY=sk-ant-api03-...
 
 # Domain used for the auth cookie in production (must match the server hostname)
+# Leave unset in development — cookie will be sent without a domain restriction
 COOKIE_DOMAIN=your-server-domain.com
+
+# Allowed client origin for CORS in production (e.g. https://myapp.vercel.app)
+# Falls back to the hard-coded Vercel URL when unset
+CLIENT_URL=https://your-client-domain.com
 
 # Port the Express server listens on (optional, defaults to 8800)
 PORT=8800

--- a/server/app.js
+++ b/server/app.js
@@ -45,8 +45,12 @@ app.use(logger);
 app.use(cookieParser());
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
+const allowedOrigins = process.env.CLIENT_URL
+  ? [process.env.CLIENT_URL, 'http://localhost:5173']
+  : ['https://garage-client-one.vercel.app', 'http://localhost:5173'];
+
 app.use(cors({
-  origin: ['https://garage-client-one.vercel.app', 'http://localhost:5173'],
+  origin: allowedOrigins,
   credentials: true,
 }));
 

--- a/server/services/authService.js
+++ b/server/services/authService.js
@@ -4,7 +4,7 @@ import { createError } from "../utils/error.js";
 import jwt from "jsonwebtoken";
 import { templatePhone } from "../utils/templates.js";
 
-const COOKIE_DOMAIN = process.env.COOKIE_DOMAIN || "garage-server-dcv1.onrender.com";
+const COOKIE_DOMAIN = process.env.COOKIE_DOMAIN;
 const isProd = () => process.env.NODE_ENV === "production";
 
 /**


### PR DESCRIPTION
## What

Two hardcoded production hostnames replaced with environment variables:

**`app.js` — CORS origin**
`'https://garage-client-one.vercel.app'` → reads from `CLIENT_URL` env var. Falls back to the current production URL when the var is unset, preserving existing deploy behaviour.

**`authService.js` — cookie domain**
`COOKIE_DOMAIN || "garage-server-dcv1.onrender.com"` → `COOKIE_DOMAIN` with no fallback. When the var is unset the `domain` option is not added to cookie options (correct for dev and staging environments where a domain restriction would break auth).

**`.env.example`** — documents both new vars with explanatory comments.

## Why

Closes #258

## Test plan

- [ ] Dev environment (no env vars set): auth cookies work, CORS allows `localhost:5173`
- [ ] Set `CLIENT_URL=https://my-staging-app.vercel.app` — CORS allows that origin
- [ ] Set `COOKIE_DOMAIN=my-server.onrender.com` — cookie has domain attribute in production mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)