### PR TITLE
fix: enforce password complexity on server-side registration (closes #260)

### DIFF
--- a/server/services/authService.js
+++ b/server/services/authService.js
@@ -33,7 +33,13 @@ const register = async (req) => {
   if (!username || !phone || !email || !password) {
     throw createError(400, "All fields are required");
   }
-  
+
+  // Password complexity: min 8 chars, at least one uppercase letter and one digit
+  const passwordPolicy = /^(?=.*[A-Z])(?=.*\d).{8,}$/;
+  if (!passwordPolicy.test(password)) {
+    throw createError(400, "Password must be at least 8 characters and include at least one uppercase letter and one number");
+  }
+
   // Check uniqueness of username, email, and phone
   const [userExists, emailExists, phoneExists] = await Promise.all([
     User.findOne({ username }),


### PR DESCRIPTION
## What

Added server-side password complexity validation in `authService.register` before hashing. The check runs after the "all fields required" guard but before the uniqueness checks (so a weak-password request fails fast without hitting the DB):

```
/^(?=.*[A-Z])(?=.*\d).{8,}$/
```

- Minimum 8 characters
- At least one uppercase letter
- At least one digit

Returns `400` with a human-readable message on failure: `"Password must be at least 8 characters and include at least one uppercase letter and one number"`.

The client already enforces the same policy via `validPass` — this closes the gap for direct API calls that bypass the browser.

## Why

Closes #260

## Test plan

- [ ] `POST /api/auth/register` with `password: "abc"` → 400
- [ ] `POST /api/auth/register` with `password: "alllowercase1"` → 400 (no uppercase)
- [ ] `POST /api/auth/register` with `password: "NoDigitHere"` → 400 (no digit)
- [ ] `POST /api/auth/register` with `password: "Valid1Pass"` → 201

🤖 Generated with [Claude Code](https://claude.com/claude-code)