### PR TITLE
fix: link review author to authenticated user — reject free-text name (closes #261)

### DIFF
--- a/server/models/Review.js
+++ b/server/models/Review.js
@@ -3,6 +3,10 @@ const { Schema,SchemaTypes } = mongoose;
 
 const ReviewSchema = new mongoose.Schema(
   {
+    user: {
+      type: SchemaTypes.ObjectId,
+      ref: "User",
+    },
     name: {
       type: String,
       required: true,

--- a/server/services/reviewService.js
+++ b/server/services/reviewService.js
@@ -1,11 +1,18 @@
 import Review from "../models/Review.js";
+import User from "../models/User.js";
 import { getPaginationParams, pickAllowed } from "../utils/queryHelpers.js";
 
-const ALLOWED_REVIEW_FIELDS = ['name', 'description', 'stars'];
+const ALLOWED_REVIEW_FIELDS = ['description', 'stars'];
 
 const createReview = async (req) => {
   const safeBody = pickAllowed(req.body, ALLOWED_REVIEW_FIELDS);
-  const newReview = new Review(safeBody);
+  const author = await User.findById(req.user.id).select("username").lean();
+  if (!author) throw { status: 404, message: "User not found" };
+  const newReview = new Review({
+    ...safeBody,
+    user: req.user.id,
+    name: author.username,
+  });
   const savedReview = await newReview.save();
   return savedReview;
 };


### PR DESCRIPTION
## What

Previously `createReview` accepted `name` from the request body, allowing any user to submit a review under an arbitrary name (including impersonating others). This fix:

1. **`Review.js` model** — adds an optional `user` ObjectId ref (optional so existing reviews without the field are not broken)
2. **`reviewService.js`** — removes `name` from `ALLOWED_REVIEW_FIELDS`; fetches the authenticated user's `username` from the DB and stores it as the review's `name`; saves `user: req.user.id` for future audit use

The `name` field is preserved in the document (denormalized) so the client display code (`customer.name`) requires no changes.

## Why

Closes #261

## Test plan

- [ ] Log in, submit a review — the review's name matches your account username, not whatever you typed in the name field
- [ ] Direct `POST /api/reviews` with `{ "name": "admin", "description": "...", "stars": 5 }` — the `name` in the stored review is the caller's username, not `"admin"`
- [ ] Existing reviews (without the `user` field) continue to display normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)