### PR TITLE
refactor: delete form alias files and add glassmorphism to Account page (closes #223 #251)

### DIFF
--- a/client/src/pages/account/Account.jsx
+++ b/client/src/pages/account/Account.jsx
@@ -7,10 +7,10 @@ const Account = () => {
   useAccountInit();
 
   return (
-    <>
+    <div className="account-page">
       <AccountTables />
       <ReqService />
-    </>
+    </div>
   );
 };
 

--- a/client/src/pages/account/account.css
+++ b/client/src/pages/account/account.css
@@ -1,6 +1,24 @@
-tbody button:hover{
-    border-radius: 4px;
-    color:gray;
+tbody button:hover {
+  border-radius: 4px;
+  color: gray;
+}
+
+.account-page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+  min-height: calc(100vh - 80px);
+}
+
+.account-page .table-container {
+  background: rgba(0, 0, 0, 0.72);
+  backdrop-filter: blur(22px);
+  -webkit-backdrop-filter: blur(22px);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  color: #e5e7eb;
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 20px 20px 60px rgba(0, 0, 0, 0.6);
 }
 
 .back-btn {

--- a/client/src/pages/cars/hooks/useCarForm.js
+++ b/client/src/pages/cars/hooks/useCarForm.js
@@ -1,1 +1,0 @@
-export { useFormData as useCarForm } from "../../../hooks/useFormData";

--- a/client/src/pages/cars/hooks/useCarHandlers.js
+++ b/client/src/pages/cars/hooks/useCarHandlers.js
@@ -1,4 +1,4 @@
-import { useCarForm } from "./useCarForm";
+import { useFormData as useCarForm } from "../../../hooks/useFormData";
 import { useCarActions } from "./useCarActions";
 import { useCarsUIStore } from "../../../stores/uiStores";
 

--- a/client/src/pages/servicesAdmin/hooks/useServiceForm.js
+++ b/client/src/pages/servicesAdmin/hooks/useServiceForm.js
@@ -1,1 +1,0 @@
-export { useFormData as useServiceForm } from "../../../hooks/useFormData";

--- a/client/src/pages/servicesAdmin/hooks/useServiceHandlers.js
+++ b/client/src/pages/servicesAdmin/hooks/useServiceHandlers.js
@@ -1,4 +1,4 @@
-import { useServiceForm } from "./useServiceForm";
+import { useFormData as useServiceForm } from "../../../hooks/useFormData";
 import { useServiceActions } from "./useServiceActions";
 import { useServicesUIStore } from "../../../stores/uiStores";
 


### PR DESCRIPTION
## What

**#251 — Delete `useCarForm.js` and `useServiceForm.js` alias files**

Both files were single-line re-exports:
```js
export { useFormData as useCarForm } from "../../../hooks/useFormData";
```

Deleted both. Updated the two callers to import `useFormData` directly:
- `useCarHandlers.js` → `import { useFormData as useCarForm } from "../../../hooks/useFormData"`
- `useServiceHandlers.js` → `import { useFormData as useServiceForm } from "../../../hooks/useFormData"`

**#223 — Glassmorphism styling for the Account / My Cars page**

The Account page had only a 3-line hover rule in `account.css`. Added:
- `.account-page` — max-width container with padding, matching Dashboard/Appointments
- `.account-page .table-container` — dark glassmorphism background, blur, border, rounded corners
- Wrapped `Account.jsx` content in `<div className="account-page">`

## Why

Closes #223, closes #251

## Test plan

- [ ] Navigate to `/myCars` — page renders with dark glassmorphism card, no white box
- [ ] Create/Edit car actions still work (form hooks are unchanged)
- [ ] Service admin edit form still works
- [ ] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)