### PR TITLE
refactor: extract getPaginatedWithPopulate helper to eliminate duplication (closes #255)

### DIFF
--- a/server/services/carService.js
+++ b/server/services/carService.js
@@ -2,7 +2,7 @@ import Car from "../models/Car.js";
 import User from "../models/User.js";
 import { templateCar } from "../utils/templates.js";
 import { createError } from "../utils/error.js";
-import { getPaginationParams, pickAllowed } from "../utils/queryHelpers.js";
+import { getPaginationParams, pickAllowed, getPaginatedWithPopulate } from "../utils/queryHelpers.js";
 
 const ALLOWED_CAR_POPULATE_FIELDS = ['services', 'owner'];
 const ALLOWED_CAR_UPDATE_FIELDS = ['numberPlate', 'km', 'brand'];
@@ -70,15 +70,8 @@ const getCars = async (req) => {
   return cars;
 };
 
-const getCarsByType = async (req) => {
-  const type = req.query.populate;
-  if (!ALLOWED_CAR_POPULATE_FIELDS.includes(type)) {
-    throw createError(400, `Invalid populate field. Allowed: ${ALLOWED_CAR_POPULATE_FIELDS.join(', ')}`);
-  }
-  const { limit, page } = getPaginationParams(req);
-  const cars = await Car.find().populate(type).skip((page - 1) * limit).limit(limit);
-  return cars;
-};
+const getCarsByType = async (req) =>
+  getPaginatedWithPopulate(Car, req, ALLOWED_CAR_POPULATE_FIELDS);
 
 const getCarsWithService = async (req) => {
   const { limit, page } = getPaginationParams(req);

--- a/server/services/messageService.js
+++ b/server/services/messageService.js
@@ -1,7 +1,7 @@
 import Message from "../models/Message.js";
 import User from "../models/User.js";
 import { createError } from "../utils/error.js";
-import { getPaginationParams, pickAllowed } from "../utils/queryHelpers.js";
+import { getPaginationParams, pickAllowed, getPaginatedWithPopulate } from "../utils/queryHelpers.js";
 
 const ALLOWED_MESSAGE_POPULATE_FIELDS = ['from', 'to'];
 const ALLOWED_MESSAGE_FIELDS = ['title', 'description'];
@@ -95,15 +95,8 @@ const getMessages = async (req) => {
   return messages;
 };
 
-const getMessagesByType = async (req) => {
-  const type = req.query.populate;
-  if (!ALLOWED_MESSAGE_POPULATE_FIELDS.includes(type)) {
-    throw createError(400, `Invalid populate field. Allowed: ${ALLOWED_MESSAGE_POPULATE_FIELDS.join(', ')}`);
-  }
-  const { limit, page } = getPaginationParams(req);
-  const messages = await Message.find().populate(type, "-password").skip((page - 1) * limit).limit(limit);
-  return messages;
-};
+const getMessagesByType = async (req) =>
+  getPaginatedWithPopulate(Message, req, ALLOWED_MESSAGE_POPULATE_FIELDS, { populateSelect: '-password' });
 
 const messageService = {
   createMessage,

--- a/server/services/serviceService.js
+++ b/server/services/serviceService.js
@@ -1,7 +1,7 @@
 import Service from "../models/Service.js";
 import Car from "../models/Car.js";
 import { createError } from "../utils/error.js";
-import { getPaginationParams, pickAllowed } from "../utils/queryHelpers.js";
+import { getPaginationParams, pickAllowed, getPaginatedWithPopulate } from "../utils/queryHelpers.js";
 
 const ALLOWED_SERVICE_POPULATE_FIELDS = ['car'];
 const ALLOWED_SERVICE_UPDATE_FIELDS = ['title', 'description', 'price', 'paid', 'status'];
@@ -64,15 +64,8 @@ const getServices = async (req) => {
   return services;
 };
 
-const getServicesByType = async (req) => {
-  const type = req.query.populate;
-  if (!ALLOWED_SERVICE_POPULATE_FIELDS.includes(type)) {
-    throw createError(400, `Invalid populate field. Allowed: ${ALLOWED_SERVICE_POPULATE_FIELDS.join(', ')}`);
-  }
-  const { limit, page } = getPaginationParams(req);
-  const services = await Service.find().populate(type).skip((page - 1) * limit).limit(limit);
-  return services;
-};
+const getServicesByType = async (req) =>
+  getPaginatedWithPopulate(Service, req, ALLOWED_SERVICE_POPULATE_FIELDS);
 
 const getServicesByCar = async (req) => {
   const { limit, page } = getPaginationParams(req);

--- a/server/services/userService.js
+++ b/server/services/userService.js
@@ -5,7 +5,7 @@ import Service from "../models/Service.js";
 import bcrypt from "bcryptjs";
 import { templatePhone } from "../utils/templates.js";
 import { createError } from "../utils/error.js";
-import { getPaginationParams, pickAllowed } from "../utils/queryHelpers.js";
+import { getPaginationParams, pickAllowed, getPaginatedWithPopulate } from "../utils/queryHelpers.js";
 
 const ALLOWED_POPULATE_FIELDS = ['cars', 'messages'];
 
@@ -94,15 +94,8 @@ const getUsers = async (req) => {
   return users;
 };
 
-const getUsersByType = async (req) => {
-  const type = req.query.populate;
-  if (!ALLOWED_POPULATE_FIELDS.includes(type)) {
-    throw createError(400, `Invalid populate field. Allowed: ${ALLOWED_POPULATE_FIELDS.join(', ')}`);
-  }
-  const { limit, page } = getPaginationParams(req);
-  const users = await User.find().select("-password").populate(type).skip((page - 1) * limit).limit(limit);
-  return users;
-};
+const getUsersByType = async (req) =>
+  getPaginatedWithPopulate(User, req, ALLOWED_POPULATE_FIELDS, { selectFields: '-password' });
 
 const userService = {
   getUsersByType,

--- a/server/utils/queryHelpers.js
+++ b/server/utils/queryHelpers.js
@@ -1,3 +1,5 @@
+import { createError } from "./error.js";
+
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 5000;
 
@@ -8,3 +10,25 @@ export const getPaginationParams = (req) => ({
 
 export const pickAllowed = (body, allowedFields) =>
   Object.fromEntries(Object.entries(body).filter(([k]) => allowedFields.includes(k)));
+
+/**
+ * Validates the populate param, then returns a paginated query result.
+ * @param {import("mongoose").Model} Model
+ * @param {import("express").Request} req
+ * @param {string[]} allowedFields - Accepted populate values
+ * @param {{ baseQuery?: object, selectFields?: string, populateSelect?: string }} opts
+ */
+export const getPaginatedWithPopulate = async (
+  Model, req, allowedFields,
+  { baseQuery = {}, selectFields = '', populateSelect = '' } = {}
+) => {
+  const type = req.query.populate;
+  if (!allowedFields.includes(type))
+    throw createError(400, `Invalid populate field. Allowed: ${allowedFields.join(', ')}`);
+  const { limit, page } = getPaginationParams(req);
+  const q = Model.find(baseQuery);
+  if (selectFields) q.select(selectFields);
+  if (populateSelect) q.populate(type, populateSelect);
+  else q.populate(type);
+  return q.skip((page - 1) * limit).limit(limit);
+};


### PR DESCRIPTION
## What

Every `getByType` function in 4 service files repeated the same 7-line populate-validation + pagination pattern. Added `getPaginatedWithPopulate()` to `server/utils/queryHelpers.js`:

```js
export const getPaginatedWithPopulate = async (
  Model, req, allowedFields,
  { baseQuery = {}, selectFields = '', populateSelect = '' } = {}
) => { ... };
```

Replaced the boilerplate in all four callers:

| Service | Before | After | Options used |
|---|---|---|---|
| `carService.getCarsByType` | 7 lines | 2 lines | — |
| `userService.getUsersByType` | 7 lines | 2 lines | `selectFields: '-password'` |
| `messageService.getMessagesByType` | 7 lines | 2 lines | `populateSelect: '-password'` |
| `serviceService.getServicesByType` | 7 lines | 2 lines | — |

Net: −36 lines, +18 lines (helper) = −18 lines overall.

## Why

Closes #255

## Test plan

- [ ] All 19 server tests pass
- [ ] Server lint passes
- [ ] `GET /api/cars?populate=owner` returns paginated cars with owner populated
- [ ] `GET /api/users?populate=messages` returns paginated users with messages
- [ ] `GET /api/messages?populate=from` — `from` user has no `password` field in response
- [ ] `GET /api/cars?populate=invalid` → 400 "Invalid populate field. Allowed: services, owner"

🤖 Generated with [Claude Code](https://claude.com/claude-code)