### PR TITLE
refactor: extract extractErrorMessage + consolidate carFilterFn (closes #249 #250)

### DIFF
--- a/client/src/pages/account/hooks/useAccountActions.js
+++ b/client/src/pages/account/hooks/useAccountActions.js
@@ -1,6 +1,5 @@
 import { createReqService } from "../../../api/services/messageApi";
-
-const extractErrorMessage = (err) => err?.response?.data?.message ?? err?.message ?? String(err);
+import { extractErrorMessage } from "../../../utils/handlerUtils";
 
 /**
  * Custom hook for account service operations

--- a/client/src/pages/account/hooks/useAccountTableData.js
+++ b/client/src/pages/account/hooks/useAccountTableData.js
@@ -1,7 +1,7 @@
 import { useUserStore } from "../../../stores/userStore";
 import { useAccountUIStore } from "../../../stores/uiStores";
 import useFilteredData from "../../../hooks/useFilteredData";
-import { carFilterFn } from "../utils/accountValidation";
+import { carFilterFn } from "../../../utils/filterUtils";
 import { handleCarAction as handleCarActionUtil } from "../utils/accountHandlerUtils";
 
 export function useAccountTableData() {

--- a/client/src/pages/account/utils/accountValidation.js
+++ b/client/src/pages/account/utils/accountValidation.js
@@ -1,15 +1,4 @@
 /**
- * Car filter function for search
- * @param {Object} item - Car object
- * @param {string} value - Search value
- * @returns {boolean} - True if matches
- */
-export const carFilterFn = (item, value) =>
-  item.numberPlate.includes(value) ||
-  item.km.toString().includes(value) ||
-  item.brand.includes(value);
-
-/**
  * Service filter function for search
  * @param {Object} service - Service object
  * @param {string} value - Search value

--- a/client/src/pages/cars/hooks/useCarActions.js
+++ b/client/src/pages/cars/hooks/useCarActions.js
@@ -1,7 +1,6 @@
 import { updateCar, deleteCar } from "../../../api/services/carApi";
 import { createService } from "../../../api/services/serviceApi";
-
-const extractErrorMessage = (err) => err?.response?.data?.message ?? err?.message ?? String(err);
+import { extractErrorMessage } from "../../../utils/handlerUtils";
 
 /**
  * Custom hook for car CRUD operations

--- a/client/src/pages/cars/hooks/useCarsTableData.js
+++ b/client/src/pages/cars/hooks/useCarsTableData.js
@@ -4,7 +4,7 @@ import { useUserStore } from "../../../stores/userStore";
 import { useCarsUIStore } from "../../../stores/uiStores";
 import { useCarAdminHandlers } from "./useCarAdminHandlers";
 import useFilteredData from "../../../hooks/useFilteredData";
-import { carFilterFn } from "../utils/carValidation";
+import { carFilterFn } from "../../../utils/filterUtils";
 import { exportToCsv } from "../../../utils/exportCsv";
 
 export function useCarsTableData() {

--- a/client/src/pages/cars/utils/carValidation.js
+++ b/client/src/pages/cars/utils/carValidation.js
@@ -1,13 +1,2 @@
-/**
- * Car filter function for search
- * @param {Object} item - Car object
- * @param {string} value - Search value
- * @returns {boolean} - True if matches
- */
-export const carFilterFn = (item, value) =>
-  item.owner?.username?.includes(value) ||
-  item.numberPlate?.includes(value) ||
-  item.km?.toString().includes(value) ||
-  item.brand?.includes(value);
-
 export { serviceStatusOptions } from "../../../utils/serviceConstants";
+export { carFilterFn } from "../../../utils/filterUtils";

--- a/client/src/pages/messages/hooks/useMessageActions.js
+++ b/client/src/pages/messages/hooks/useMessageActions.js
@@ -3,8 +3,7 @@ import {
   createMessage,
   createMessageToAdmin,
 } from "../../../api/services/messageApi";
-
-const extractErrorMessage = (err) => err?.response?.data?.message ?? err?.message ?? String(err);
+import { extractErrorMessage } from "../../../utils/handlerUtils";
 
 /**
  * Custom hook for message CRUD operations

--- a/client/src/pages/servicesAdmin/hooks/useServiceActions.js
+++ b/client/src/pages/servicesAdmin/hooks/useServiceActions.js
@@ -1,6 +1,5 @@
 import { deleteService, updateService } from "../../../api/services/serviceApi";
-
-const extractErrorMessage = (err) => err?.response?.data?.message ?? err?.message ?? String(err);
+import { extractErrorMessage } from "../../../utils/handlerUtils";
 
 /**
  * Custom hook for service CRUD operations

--- a/client/src/pages/users/hooks/useUserActions.js
+++ b/client/src/pages/users/hooks/useUserActions.js
@@ -1,7 +1,7 @@
 import { deleteUser, updateUser, createUser } from "../../../api/services/userApi";
 import { createCar } from "../../../api/services/carApi";
 import { isValidUserName, isValidCar } from "../utils/userValidation";
-const extractErrorMessage = (err) => err?.response?.data?.message ?? err?.message ?? String(err);
+import { extractErrorMessage } from "../../../utils/handlerUtils";
 
 /**
  * Custom hook for user CRUD operations

--- a/client/src/utils/filterUtils.js
+++ b/client/src/utils/filterUtils.js
@@ -1,0 +1,9 @@
+/**
+ * Car filter function for search — shared by admin Cars table and user My Cars table.
+ * Includes owner.username so admins can filter by owner name.
+ */
+export const carFilterFn = (item, value) =>
+  item.owner?.username?.includes(value) ||
+  item.numberPlate?.includes(value) ||
+  item.km?.toString().includes(value) ||
+  item.brand?.includes(value);

--- a/client/src/utils/handlerUtils.js
+++ b/client/src/utils/handlerUtils.js
@@ -9,6 +9,9 @@
  * @param {Function} setSelected - State setter for the selected entity
  * @returns {string} The button's name attribute
  */
+export const extractErrorMessage = (err) =>
+  err?.response?.data?.message ?? err?.message ?? String(err);
+
 export const resolveActionTarget = (e, items, setSelected) => {
   e.preventDefault();
   const { name, value } = e.target;


### PR DESCRIPTION
## What

**#249 — `extractErrorMessage` moved to shared `handlerUtils.js`**

`extractErrorMessage` was copy-pasted identically in 5 hook files:
```js
const extractErrorMessage = (err) => err?.response?.data?.message ?? err?.message ?? String(err);
```
Added it to `client/src/utils/handlerUtils.js` and replaced the local declaration in all 5 callers with a single import.

**#250 — `carFilterFn` consolidated into `filterUtils.js`**

Two files defined `carFilterFn` with diverging fields:
- `cars/utils/carValidation.js` — included `owner.username` (correct)
- `account/utils/accountValidation.js` — missing `owner.username` (bug risk)

Created `client/src/utils/filterUtils.js` with the canonical version (includes `owner.username`). Updated both callers (`useCarsTableData`, `useAccountTableData`) to import from the shared util. Removed the definitions from both validation files (carValidation now re-exports from filterUtils for any remaining importers).

## Why

Closes #249, closes #250

## Test plan

- [ ] Admin Cars search — filtering by owner username works
- [ ] My Cars search — filtering by plate, km, brand works
- [ ] All action hooks (create/edit/delete car, service, message) still surface errors correctly
- [ ] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)