### PR TITLE
fix: unhandledRejection crash, agent axios, Review index, dead code (closes #284 #285 #286 #288)

### DIFF
--- a/client/src/components/agent/hooks/useAgentChat.js
+++ b/client/src/components/agent/hooks/useAgentChat.js
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from "react";
+import axios from "../../../axiosConfig.js";
 
 const BOT_INTRO = {
   id: "intro",
@@ -38,13 +39,10 @@ export function useAgentChat() {
     setIsLoading(true);
 
     try {
-      const res = await fetch("/api/agent/chat", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
-        body: JSON.stringify({ message: text, history: messages }),
+      const { data } = await axios.post("/agent/chat", {
+        message: text,
+        history: messages,
       });
-      const data = await res.json();
       const botMsg = {
         id: Date.now() + 1,
         role: "assistant",

--- a/client/src/validation/valid.js
+++ b/client/src/validation/valid.js
@@ -5,8 +5,6 @@ import validCar from "./validCar.js";
 import validEmail from "./validEmail.js";
 import validPass from "./validPass.js";
 
-//TODO: Add more validation if existing(email, phone, username, etc)
-
 // Constants for input validation messages and patterns
 const INPUT_TYPES = {
   email: {

--- a/server/index.js
+++ b/server/index.js
@@ -18,6 +18,7 @@ const port = process.env.PORT || 8800;
 
 process.on("unhandledRejection", (reason) => {
   console.error("Unhandled promise rejection:", reason);
+  process.exit(1);
 });
 
 async function start() {

--- a/server/models/Message.js
+++ b/server/models/Message.js
@@ -27,11 +27,9 @@ const MessageSchema = new Schema(
       minlength: [2, 'Description must be at least 2 characters'],
       maxlength: [5000, 'Description must be at most 5000 characters'],
     },  
-    // read or not read  
     read: {
       type: Boolean,
-      default:false,
-      // required: true,
+      default: false,
     }
   },
   { timestamps: true }

--- a/server/models/Review.js
+++ b/server/models/Review.js
@@ -28,4 +28,5 @@ const ReviewSchema = new mongoose.Schema(
   },
   { timestamps: true }
 );
+ReviewSchema.index({ user: 1 });
 export default mongoose.model("Review", ReviewSchema);


### PR DESCRIPTION
## What

Four single-file fixes bundled:

| # | File | Fix |
|---|---|---|
| **#284** | `server/index.js` | Add `process.exit(1)` after logging `unhandledRejection` — Node 15+ no longer crashes by default, so without this the process stays alive in a broken state preventing clean restarts by a process manager |
| **#285** | `useAgentChat.js` | Replace raw `fetch()` with the shared `axios` instance from `axiosConfig.js`; fixes two bugs: (1) 401 responses no longer bypass the `clearAuth` interceptor, (2) non-JSON error bodies no longer throw silently |
| **#286** | `Review.js` model | Add `ReviewSchema.index({ user: 1 })` — enables efficient per-user review queries, consistent with Appointment/Message/User model patterns |
| **#288** | `valid.js` + `Message.js` | Remove stale `//TODO:` comment (validation already exists); remove dead `// required: true` comment from Message.read field |

## Why

Closes #284, closes #285, closes #286, closes #288

## Test plan

- [ ] Kill DB connection mid-request — server now exits instead of staying alive
- [ ] Expire JWT while agent chat is open — user is redirected to `/` (interceptor fires)
- [ ] `GET /api/reviews?user=<id>` uses the new index (check with `explain()`)
- [ ] `npm run lint` passes on both client and server

🤖 Generated with [Claude Code](https://claude.com/claude-code)