### PR TITLE
feat: add CSV export button to Dashboard overview (closes #269)

### DIFF
--- a/client/src/pages/dashboard/Dashboard.jsx
+++ b/client/src/pages/dashboard/Dashboard.jsx
@@ -7,6 +7,7 @@ import {
   RecentMessages,
   MonthlyTrends,
 } from "../../components/dashboard";
+import { exportToCsv } from "../../utils/exportCsv";
 import "./Dashboard.css";
 
 const Dashboard = () => {
@@ -26,10 +27,29 @@ const Dashboard = () => {
 
   if (!stats?.overview) return null;
 
+  const handleExport = () => {
+    const o = stats.overview;
+    exportToCsv(
+      [
+        { metric: "Total Users",        value: o.totalUsers },
+        { metric: "Total Cars",         value: o.totalCars },
+        { metric: "Total Services",     value: o.totalServices },
+        { metric: "Total Appointments", value: o.totalAppointments },
+        { metric: "Total Messages",     value: o.totalMessages },
+        { metric: "Total Reviews",      value: o.totalReviews },
+        { metric: "Average Rating",     value: o.averageRating },
+      ],
+      "dashboard-stats"
+    );
+  };
+
   return (
     <div className="dashboard-container">
       <div className="dashboard-header">
         <h1 className="dashboard-title">Dashboard</h1>
+        <button className="refresh-button" onClick={handleExport} title="Export overview stats to CSV">
+          ⬇ Export CSV
+        </button>
       </div>
       <StatsOverview />
       <AppointmentsByStatus />


### PR DESCRIPTION
## What
Adds an **Export CSV** button to the Dashboard header. Clicking it downloads a one-row-per-metric CSV of the aggregate stats: total users, cars, services, appointments, messages, reviews, and average rating — using the existing `exportToCsv` utility (no new dependencies).

All six admin list views (users, cars, services, messages, contacts, appointments) already had CSV export wired up. This adds the last missing surface: the Dashboard itself.

## Why
Closes #269

## Test plan
- [ ] Open the Dashboard as an admin
- [ ] Click **⬇ Export CSV** in the header — a `dashboard-stats.csv` file downloads
- [ ] Verify the CSV contains 7 rows (one per metric) with correct values
- [ ] Confirm no console errors and no visual regressions in the header layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)