### PR TITLE
fix: add strict rate limiter for public write endpoints (closes #270)

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -39,6 +39,14 @@ const agentLimiter = rateLimit({
   legacyHeaders: false,
 });
 
+const publicWriteLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 5,
+  message: { message: "Too many submissions, please try again later" },
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
 const app = express();
 
 app.use(logger);
@@ -60,7 +68,9 @@ app.use("/api/cars", publicLimiter, carsRoute);
 app.use("/api/services", publicLimiter, servicesRoute);
 app.use("/api/messages", publicLimiter, messagesRoute);
 app.use("/api/reviews", publicLimiter, reviewsRoute);
+app.post("/api/contacts", publicWriteLimiter);
 app.use("/api/contacts", publicLimiter, contactsRoute);
+app.post("/api/appointments", publicWriteLimiter);
 app.use("/api/appointments", publicLimiter, appointmentsRoute);
 app.use("/api/dashboard", publicLimiter, dashboardRoute);
 app.use("/api/agent", agentLimiter, agentRoute);


### PR DESCRIPTION
## What
Adds a dedicated `publicWriteLimiter` (5 requests / 15 min per IP) applied specifically to `POST /api/contacts` and `POST /api/appointments` in `server/app.js`, stacked before the existing `publicLimiter` (50 req / 15 min).

The tighter limiter runs first — if exceeded it returns `429` immediately. Authenticated admin/user endpoints on the same routers (`GET`, `PUT`, `PATCH`, `DELETE`) are untouched and continue using the general 50 req / 15 min limiter.

No dependencies added. No route file changes.

## Why
Closes #270

`POST /api/contacts` and `POST /api/appointments` are public (unauthenticated). A single IP could previously submit 50 spam items per 15 minutes. The new limit reduces this to 5, which is sufficient for any legitimate user.

## Test plan
- [ ] Submit a contact form 5 times from the same IP — 6th attempt returns `429`
- [ ] Submit an appointment 5 times from the same IP — 6th attempt returns `429`
- [ ] Admin can still fetch/update/delete contacts and appointments without hitting the tight limit
- [ ] Server lint and tests pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)