### PR TITLE
refactor: consolidate Delete* wrappers into shared DeleteModal (closes #253)

### DIFF
--- a/client/src/components/delete/DeleteCar.jsx
+++ b/client/src/components/delete/DeleteCar.jsx
@@ -1,20 +1,18 @@
-import Delete from "./Delete";
+import DeleteModal from "./DeleteModal";
 import { useCarsUIStore } from "../../stores/uiStores";
 import { useCarHandlers } from "../../pages/cars/hooks/useCarHandlers";
-const DeleteCar = () => {
-  const selectedCar = useCarsUIStore((s) => s.selectedCar);
-  const deleteCarOpen = useCarsUIStore((s) => s.deleteCarOpen);
-  const toggleDeleteCar = useCarsUIStore((s) => s.toggleDeleteCar);
-  const { useDeleteCar } = useCarHandlers();
-  return (
-    <Delete
-      deleteData={selectedCar?.numberPlate}
-      handle={toggleDeleteCar}
-      nameData="deleteCar"
-      isOpen={deleteCarOpen}
-      handleDelete={useDeleteCar}
-    />
-  );
-};
+
+const DeleteCar = () => (
+  <DeleteModal
+    useStore={useCarsUIStore}
+    selectedKey="selectedCar"
+    isOpenKey="deleteCarOpen"
+    toggleKey="toggleDeleteCar"
+    useHandlers={useCarHandlers}
+    handlerKey="useDeleteCar"
+    displayField="numberPlate"
+    nameData="deleteCar"
+  />
+);
 
 export default DeleteCar;

--- a/client/src/components/delete/DeleteMessage.jsx
+++ b/client/src/components/delete/DeleteMessage.jsx
@@ -1,20 +1,18 @@
-import Delete from "./Delete";
+import DeleteModal from "./DeleteModal";
 import { useMessagesUIStore } from "../../stores/uiStores";
 import { useMessageHandlers } from "../../pages/messages/hooks/useMessageHandlers";
-const DeleteMessage = () => {
-  const selectedMsg = useMessagesUIStore((s) => s.selectedMsg);
-  const deleteMsgOpen = useMessagesUIStore((s) => s.deleteMsgOpen);
-  const toggleDeleteMsg = useMessagesUIStore((s) => s.toggleDeleteMsg);
-  const { useDeleteMsg } = useMessageHandlers();
-  return (
-    <Delete
-      deleteData={selectedMsg?.title}
-      handle={toggleDeleteMsg}
-      nameData="deleteMessage"
-      isOpen={deleteMsgOpen}
-      handleDelete={useDeleteMsg}
-    />
-  );
-};
+
+const DeleteMessage = () => (
+  <DeleteModal
+    useStore={useMessagesUIStore}
+    selectedKey="selectedMsg"
+    isOpenKey="deleteMsgOpen"
+    toggleKey="toggleDeleteMsg"
+    useHandlers={useMessageHandlers}
+    handlerKey="useDeleteMsg"
+    displayField="title"
+    nameData="deleteMessage"
+  />
+);
 
 export default DeleteMessage;

--- a/client/src/components/delete/DeleteModal.jsx
+++ b/client/src/components/delete/DeleteModal.jsx
@@ -1,0 +1,28 @@
+import Delete from "./Delete";
+
+const DeleteModal = ({
+  useStore,
+  selectedKey,
+  isOpenKey,
+  toggleKey,
+  useHandlers,
+  handlerKey,
+  displayField,
+  nameData,
+}) => {
+  const item   = useStore((s) => s[selectedKey]);
+  const isOpen = useStore((s) => s[isOpenKey]);
+  const toggle = useStore((s) => s[toggleKey]);
+  const handler = useHandlers()[handlerKey];
+  return (
+    <Delete
+      deleteData={item?.[displayField]}
+      handle={toggle}
+      nameData={nameData}
+      isOpen={isOpen}
+      handleDelete={handler}
+    />
+  );
+};
+
+export default DeleteModal;

--- a/client/src/components/delete/DeleteUser.jsx
+++ b/client/src/components/delete/DeleteUser.jsx
@@ -1,21 +1,18 @@
-import Delete from "./Delete";
+import DeleteModal from "./DeleteModal";
 import { useUsersUIStore } from "../../stores/uiStores";
 import { useUserHandlers } from "../../pages/users/hooks/useUserHandlers";
 
-const DeleteUser = () => {
-  const selectedUser = useUsersUIStore((s) => s.selectedUser);
-  const deleteUserOpen = useUsersUIStore((s) => s.deleteUserOpen);
-  const toggleDeleteUser = useUsersUIStore((s) => s.toggleDeleteUser);
-  const { useDeleteUser } = useUserHandlers();
-  return (
-    <Delete
-      deleteData={selectedUser?.username}
-      handle={toggleDeleteUser}
-      nameData="deleteUser"
-      isOpen={deleteUserOpen}
-      handleDelete={useDeleteUser}
-    />
-  );
-};
+const DeleteUser = () => (
+  <DeleteModal
+    useStore={useUsersUIStore}
+    selectedKey="selectedUser"
+    isOpenKey="deleteUserOpen"
+    toggleKey="toggleDeleteUser"
+    useHandlers={useUserHandlers}
+    handlerKey="useDeleteUser"
+    displayField="username"
+    nameData="deleteUser"
+  />
+);
 
 export default DeleteUser;


### PR DESCRIPTION
## What
Extracts the repeated pattern shared by `DeleteUser`, `DeleteCar`, and `DeleteMessage` into a new `DeleteModal` component. Each of the three wrappers was doing the same three things:
1. Select `selected*`, `delete*Open`, and `toggle*` from a UI store
2. Call a handlers hook and destructure the delete handler
3. Render `<Delete>` with mapped props

`DeleteModal` receives the store hook, key names, handlers hook, handler key, display field, and nameData as props and handles all the wiring internally. Each wrapper is now a 12-line config declaration.

## Why
Closes #253

## Test plan
- [ ] Delete User flow works (select user → Manage → Delete → confirm)
- [ ] Delete Car flow works
- [ ] Delete Message flow works
- [ ] Client lint and unit tests pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)