### PR TITLE
refactor: extract createActionHandler factory (closes #254)

### DIFF
--- a/client/src/pages/cars/utils/carHandlerUtils.js
+++ b/client/src/pages/cars/utils/carHandlerUtils.js
@@ -1,16 +1,6 @@
-import { resolveActionTarget } from "../../../utils/handlerUtils";
+import { createActionHandler } from "../../../utils/handlerUtils";
 
-export const handleCarAction = (
-  e,
-  cars,
-  setSelectedCar,
-  { toggleManageCar, toggleEditCar, toggleCreateService, toggleDeleteCar }
-) => {
-  const name = resolveActionTarget(e, cars, setSelectedCar);
-  switch (name) {
-    case "editCar":        toggleEditCar();        break;
-    case "createService":  toggleCreateService();  break;
-    case "deleteCar":      toggleDeleteCar();      break;
-    default:               toggleManageCar();
-  }
-};
+export const handleCarAction = createActionHandler(
+  { editCar: "toggleEditCar", createService: "toggleCreateService", deleteCar: "toggleDeleteCar" },
+  "toggleManageCar"
+);

--- a/client/src/pages/messages/utils/messageHandlerUtils.js
+++ b/client/src/pages/messages/utils/messageHandlerUtils.js
@@ -1,14 +1,6 @@
-import { resolveActionTarget } from "../../../utils/handlerUtils";
+import { createActionHandler } from "../../../utils/handlerUtils";
 
-export const handleMessageAction = (
-  e,
-  messages,
-  setSelectedMsg,
-  { toggleCreateMsg, toggleDeleteMsg }
-) => {
-  const name = resolveActionTarget(e, messages, setSelectedMsg);
-  switch (name) {
-    case "createMessage": toggleCreateMsg(); break;
-    case "deleteMessage":  toggleDeleteMsg();  break;
-  }
-};
+export const handleMessageAction = createActionHandler({
+  createMessage: "toggleCreateMsg",
+  deleteMessage: "toggleDeleteMsg",
+});

--- a/client/src/pages/users/utils/userHandlerUtils.js
+++ b/client/src/pages/users/utils/userHandlerUtils.js
@@ -1,16 +1,6 @@
-import { resolveActionTarget } from "../../../utils/handlerUtils";
+import { createActionHandler } from "../../../utils/handlerUtils";
 
-export const handleUserAction = (
-  e,
-  users,
-  setSelectedUser,
-  { toggleManageUser, toggleEditUser, toggleCreateCar, toggleDeleteUser }
-) => {
-  const name = resolveActionTarget(e, users, setSelectedUser);
-  switch (name) {
-    case "editUser":   toggleEditUser();   break;
-    case "createCar":  toggleCreateCar();  break;
-    case "deleteUser": toggleDeleteUser(); break;
-    default:           toggleManageUser();
-  }
-};
+export const handleUserAction = createActionHandler(
+  { editUser: "toggleEditUser", createCar: "toggleCreateCar", deleteUser: "toggleDeleteUser" },
+  "toggleManageUser"
+);

--- a/client/src/utils/handlerUtils.js
+++ b/client/src/utils/handlerUtils.js
@@ -18,3 +18,11 @@ export const resolveActionTarget = (e, items, setSelected) => {
   setSelected(items.find((item) => item._id === value));
   return name;
 };
+
+export const createActionHandler =
+  (actionMap, defaultKey) =>
+  (e, items, setSelected, toggles) => {
+    const name = resolveActionTarget(e, items, setSelected);
+    const fn = actionMap[name] ? toggles[actionMap[name]] : toggles[defaultKey];
+    fn?.();
+  };


### PR DESCRIPTION
## What
Adds a `createActionHandler(actionMap, defaultKey)` factory to `client/src/utils/handlerUtils.js`. The factory returns `(e, items, setSelected, toggles) => …` — it calls `resolveActionTarget`, looks up the toggle function by name from `actionMap`, and calls it (or the `defaultKey` toggle for unknown actions).

Three handler utils are rewritten using the factory:
- `userHandlerUtils.js`: 17 lines → 6 lines
- `carHandlerUtils.js`: 17 lines → 6 lines
- `messageHandlerUtils.js`: 15 lines → 6 lines

`serviceHandlerUtils.js` is intentionally left unchanged — it has async `window.confirm` logic that the factory pattern doesn't accommodate.

## Why
Closes #254

## Test plan
- [ ] User Manage → Edit / Create Car / Delete all trigger the correct modal
- [ ] Car Manage → Edit / Create Service / Delete all trigger the correct modal
- [ ] Message Create / Delete all trigger the correct modal
- [ ] Service handler still works (untouched)
- [ ] Client lint and unit tests pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)