### PR TITLE
feat: add calendar view to Appointments page (closes #266)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.7.7",
+        "date-fns": "^4.4.0",
         "dotenv": "^16.4.7",
         "react": "^19.0.0",
+        "react-big-calendar": "^1.20.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.16.0",
         "zustand": "^5.0.0"
@@ -269,6 +271,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1077,6 +1088,28 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@restart/hooks": {
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.16.tgz",
+      "integrity": "sha512-f7aCv7c+nU/3mF7NWLtVVr0Ra80RqsO89hO72r+Y/nvQr5+q0UFGkocElTH6MJApvReVh6JHUFYn2cw1WdHF3w==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
@@ -1692,7 +1725,6 @@
       "version": "19.2.16",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.16.tgz",
       "integrity": "sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==",
-      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1708,6 +1740,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/warning": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.4.tgz",
+      "integrity": "sha512-CqN8MnISMwQbLJXO3doBAV4Yw9hx9/Pyr2rZ78+NfaCnhyRA/nKrpyk6E7mKw17ZOaQdLpK9GiUjrqLzBlN3sg==",
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.3.3",
@@ -2240,6 +2278,20 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/cldrjs": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/cldrjs/-/cldrjs-0.5.5.tgz",
+      "integrity": "sha512-KDwzwbmLIPfCgd8JERVDpQKrUUM1U4KpFJJg2IROv89rF172lLufoJnqJ/Wea6fXL5bO6WjuLMzY8V52UWPvkA=="
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2318,7 +2370,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-view-buffer": {
@@ -2374,6 +2425,28 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/date-arithmetic": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-arithmetic/-/date-arithmetic-4.1.0.tgz",
+      "integrity": "sha512-QWxYLR5P/6GStZcdem+V1xoto6DMadYWpMXU82ES3/RfR3Wdwr3D0+be7mgOJ+Ov0G9D5Dmb9T17sNLQYj9XOg==",
+      "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.3.7",
@@ -2445,6 +2518,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2466,6 +2548,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-6.0.1.tgz",
+      "integrity": "sha512-IKySryuFwseGkrCA/pIqlwUPOD50w1Lj/B2Yief3vBOP18k5y4t+hTqKh55gULDVeJMRitcozve+g/wVFf4sFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.1",
+        "csstype": "^3.1.3"
       }
     },
     "node_modules/dotenv": {
@@ -3220,6 +3312,15 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/globalize": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/globalize/-/globalize-1.7.1.tgz",
+      "integrity": "sha512-PFymRL0PtitFOlSniuwwwNfkooi3cLQJo9Uke1+j1DsGfUkkHkwneImqVtGcqKI0TuzhAlHt7hAcgK324902HA==",
+      "license": "MIT",
+      "dependencies": {
+        "cldrjs": "^0.5.4"
+      }
+    },
     "node_modules/globals": {
       "version": "15.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-15.12.0.tgz",
@@ -3408,6 +3509,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/is-array-buffer": {
@@ -3839,7 +3949,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -4220,6 +4329,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -4231,7 +4352,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -4248,6 +4368,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {
@@ -4301,6 +4430,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
+      "license": "MIT"
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -4330,6 +4465,27 @@
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.48",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
+      "integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.29.4"
       },
       "engines": {
         "node": "*"
@@ -4379,7 +4535,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4677,7 +4832,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -4711,6 +4865,34 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-big-calendar": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/react-big-calendar/-/react-big-calendar-1.20.0.tgz",
+      "integrity": "sha512-Lp1mvG34l/9xtb/2LsBb4UAF3iPcUkmDqbmpsvDHzp/n8GA5gtn3+nf8BsULWw08opKDgv38nQi75dQlOOqzkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "clsx": "^2.1.1",
+        "date-arithmetic": "^4.1.0",
+        "dayjs": "^1.11.21",
+        "dom-helpers": "^6.0.1",
+        "globalize": "^1.7.1",
+        "invariant": "^2.2.4",
+        "lodash": "^4.18.1",
+        "lodash-es": "^4.18.1",
+        "luxon": "^3.7.2",
+        "memoize-one": "^6.0.0",
+        "moment": "^2.29.4",
+        "moment-timezone": "^0.5.48",
+        "prop-types": "^15.8.1",
+        "react-overlays": "^5.2.1",
+        "uncontrollable": "^7.2.1"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17 || ^18 || ^19",
+        "react-dom": "^16.14.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
@@ -4728,8 +4910,43 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+      "license": "MIT"
+    },
+    "node_modules/react-overlays": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-5.2.1.tgz",
+      "integrity": "sha512-GLLSOLWr21CqtJn8geSwQfoJufdt3mfdsnIiQswouuQ2MMPns+ihZklxvsTDKD3cR2tF8ELbi5xUsvqVhR6WvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.8",
+        "@popperjs/core": "^2.11.6",
+        "@restart/hooks": "^0.4.7",
+        "@types/warning": "^3.0.0",
+        "dom-helpers": "^5.2.0",
+        "prop-types": "^15.7.2",
+        "uncontrollable": "^7.2.1",
+        "warning": "^4.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      }
+    },
+    "node_modules/react-overlays/node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.14.2",
@@ -5378,6 +5595,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/uncontrollable": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.2.1.tgz",
+      "integrity": "sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.6.3",
+        "@types/react": ">=16.9.11",
+        "invariant": "^2.2.4",
+        "react-lifecycles-compat": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react": ">=15.0.0"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -6068,6 +6300,15 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/which": {

--- a/client/package.json
+++ b/client/package.json
@@ -15,8 +15,10 @@
   },
   "dependencies": {
     "axios": "^1.7.7",
+    "date-fns": "^4.4.0",
     "dotenv": "^16.4.7",
     "react": "^19.0.0",
+    "react-big-calendar": "^1.20.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.16.0",
     "zustand": "^5.0.0"

--- a/client/src/pages/appointments/Appointments.jsx
+++ b/client/src/pages/appointments/Appointments.jsx
@@ -1,10 +1,14 @@
+import { useState } from "react";
 import "./appointments.css";
 import { useAppointmentsPage } from "./hooks/useAppointmentsPage";
 import AppointmentStats from "./components/AppointmentStats";
 import AppointmentForm from "./components/AppointmentForm";
 import AppointmentsList from "./components/AppointmentsList";
+import AppointmentCalendar from "./components/AppointmentCalendar";
 
 const Appointments = () => {
+  const [view, setView] = useState("list");
+
   const {
     users,
     stats,
@@ -22,24 +26,44 @@ const Appointments = () => {
         <p>Schedule and manage your garage appointments</p>
       </div>
       <AppointmentStats stats={stats} />
-      <div className="appointments-content">
-        <AppointmentForm
-          formData={appointmentForm.formData}
-          users={users}
-          handleChange={appointmentForm.handleChange}
-          handleSubmit={handleSubmit}
-          isLoading={fetchState.isLoading}
-        />
-        <AppointmentsList
-          filteredAppointments={appointmentFilters.filteredAppointments}
-          filterStatus={appointmentFilters.filterStatus}
-          setFilterStatus={appointmentFilters.setFilterStatus}
-          fetchState={fetchState}
-          searchTerm={appointmentFilters.searchTerm}
-          setSearchTerm={appointmentFilters.setSearchTerm}
-          handleStatusChange={handleStatusChange}
-        />
+
+      <div className="apt-view-toggle">
+        <button
+          className={`apt-view-btn${view === "list" ? " active" : ""}`}
+          onClick={() => setView("list")}
+        >
+          📋 List
+        </button>
+        <button
+          className={`apt-view-btn${view === "calendar" ? " active" : ""}`}
+          onClick={() => setView("calendar")}
+        >
+          📅 Calendar
+        </button>
       </div>
+
+      {view === "calendar" ? (
+        <AppointmentCalendar appointments={appointmentFilters.filteredAppointments} />
+      ) : (
+        <div className="appointments-content">
+          <AppointmentForm
+            formData={appointmentForm.formData}
+            users={users}
+            handleChange={appointmentForm.handleChange}
+            handleSubmit={handleSubmit}
+            isLoading={fetchState.isLoading}
+          />
+          <AppointmentsList
+            filteredAppointments={appointmentFilters.filteredAppointments}
+            filterStatus={appointmentFilters.filterStatus}
+            setFilterStatus={appointmentFilters.setFilterStatus}
+            fetchState={fetchState}
+            searchTerm={appointmentFilters.searchTerm}
+            setSearchTerm={appointmentFilters.setSearchTerm}
+            handleStatusChange={handleStatusChange}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/client/src/pages/appointments/appointments.css
+++ b/client/src/pages/appointments/appointments.css
@@ -695,3 +695,56 @@
 .action-cancelled:not(:disabled):hover {
   background: rgba(248, 113, 113, 0.3);
 }
+
+/* ── View Toggle ─────────────────────────────── */
+.apt-view-toggle {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.apt-view-btn {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: #d1d5db;
+  padding: 0.5rem 1.2rem;
+  border-radius: 0.5rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-family: inherit;
+}
+
+.apt-view-btn:hover {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: #4a9eff;
+  color: #4a9eff;
+}
+
+.apt-view-btn.active {
+  background: #2563eb;
+  border-color: #2563eb;
+  color: #fff;
+}
+
+/* ── Calendar Wrapper ────────────────────────── */
+.apt-calendar-wrapper {
+  background: rgba(255, 255, 255, 0.97);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  animation: fadeIn 0.4s ease-out;
+}
+
+.apt-calendar-wrapper .rbc-toolbar {
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.apt-calendar-wrapper .rbc-toolbar button {
+  border-radius: 0.4rem;
+}
+
+.apt-calendar-wrapper .rbc-today {
+  background-color: rgba(37, 99, 235, 0.08);
+}

--- a/client/src/pages/appointments/components/AppointmentCalendar.jsx
+++ b/client/src/pages/appointments/components/AppointmentCalendar.jsx
@@ -1,0 +1,70 @@
+import { useMemo } from "react";
+import { Calendar, dateFnsLocalizer } from "react-big-calendar";
+import { format, parse, startOfWeek, getDay } from "date-fns";
+import { enUS } from "date-fns/locale/en-US";
+import "react-big-calendar/lib/css/react-big-calendar.css";
+
+const localizer = dateFnsLocalizer({
+  format,
+  parse,
+  startOfWeek: () => startOfWeek(new Date(), { weekStartsOn: 0 }),
+  getDay,
+  locales: { "en-US": enUS },
+});
+
+const STATUS_COLORS = {
+  confirmed: "#22c55e",
+  pending: "#f59e0b",
+  cancelled: "#ef4444",
+};
+
+const appointmentToEvent = (a) => {
+  const [hours, minutes] = (a.time || "09:00").split(":").map(Number);
+  const start = new Date(a.date);
+  start.setHours(hours, minutes, 0, 0);
+  const end = new Date(start);
+  end.setHours(hours + 1, minutes, 0, 0);
+  return {
+    id: a._id,
+    title: `${a.clientName} (${a.status})`,
+    start,
+    end,
+    resource: a,
+  };
+};
+
+const eventStyleGetter = (event) => ({
+  style: {
+    backgroundColor: STATUS_COLORS[event.resource?.status] ?? "#6b7280",
+    borderRadius: "4px",
+    border: "none",
+    color: "#fff",
+    fontSize: "0.8rem",
+  },
+});
+
+const AppointmentCalendar = ({ appointments }) => {
+  const events = useMemo(() => (appointments ?? []).map(appointmentToEvent), [appointments]);
+
+  return (
+    <div className="apt-calendar-wrapper">
+      <Calendar
+        localizer={localizer}
+        events={events}
+        startAccessor="start"
+        endAccessor="end"
+        style={{ height: 600 }}
+        eventPropGetter={eventStyleGetter}
+        views={["month", "week", "day"]}
+        defaultView="month"
+        popup
+        tooltipAccessor={(e) => {
+          const a = e.resource;
+          return `${a.clientName} — ${a.email} — ${a.time} (${a.status})`;
+        }}
+      />
+    </div>
+  );
+};
+
+export default AppointmentCalendar;


### PR DESCRIPTION
## What
Adds a **Calendar** view toggle alongside the existing **List** view on the Appointments page.

- **`AppointmentCalendar.jsx`** — new component built on `react-big-calendar` with `date-fns` localizer. Renders appointments as calendar events in month/week/day views. Events are color-coded by status:
  - 🟢 confirmed
  - 🟡 pending
  - 🔴 cancelled
  - Hover tooltip shows: client name, email, time, status
- **View toggle** — two buttons (📋 List / 📅 Calendar) in the appointments header let admins switch views without losing filter state
- **Shared filter state** — the calendar receives `filteredAppointments` from the same `useAppointmentFilters` hook that powers the list, so status/search filters affect both views
- **CSS** — `.apt-view-toggle` and `.apt-calendar-wrapper` added to `appointments.css` with the same dark-glassmorphism theme. Calendar background is light for readability.

## Why
Closes #266

## Test plan
- [ ] Visit `/appointments` as an admin — List view shows by default
- [ ] Click **📅 Calendar** — calendar renders with month view and appointments as color-coded events
- [ ] Switch to Week/Day view via the calendar's own toolbar
- [ ] Hover an event — tooltip shows client details
- [ ] Apply a status filter in the app → filtered appointments update in calendar too
- [ ] Switch back to List view — form and list still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)