### PR TITLE
feat: add refresh token mechanism for seamless session renewal (closes #267)

### DIFF
--- a/client/src/axiosConfig.js
+++ b/client/src/axiosConfig.js
@@ -5,14 +5,50 @@ axios.defaults.baseURL = import.meta.env.VITE_API_URL || "http://localhost:8800/
 
 axios.defaults.withCredentials = true;
 
+let isRefreshing = false;
+let failedQueue = [];
+
+const processQueue = (error) => {
+  failedQueue.forEach((p) => (error ? p.reject(error) : p.resolve()));
+  failedQueue = [];
+};
+
 axios.interceptors.response.use(
   (response) => response,
   async (error) => {
-    if (error.response?.status === 401) {
-      // clearAuth avoids an API call so this interceptor cannot loop
-      useAuthStore.getState().clearAuth();
-      window.location.replace("/");
+    const originalRequest = error.config;
+
+    // Skip retry for refresh calls themselves to prevent infinite loops
+    if (
+      error.response?.status === 401 &&
+      !originalRequest._retry &&
+      !originalRequest.url?.includes("/auth/refresh")
+    ) {
+      if (isRefreshing) {
+        return new Promise((resolve, reject) => {
+          failedQueue.push({ resolve, reject });
+        })
+          .then(() => axios(originalRequest))
+          .catch((err) => Promise.reject(err));
+      }
+
+      originalRequest._retry = true;
+      isRefreshing = true;
+
+      try {
+        await axios.post("/auth/refresh");
+        processQueue(null);
+        return axios(originalRequest);
+      } catch (refreshError) {
+        processQueue(refreshError);
+        useAuthStore.getState().clearAuth();
+        window.location.replace("/");
+        return Promise.reject(refreshError);
+      } finally {
+        isRefreshing = false;
+      }
     }
+
     return Promise.reject(error);
   }
 );

--- a/server/controllers/auth.js
+++ b/server/controllers/auth.js
@@ -7,23 +7,37 @@ export const register = createHandler(authService.register, 201);
 // Admin ID lookup — authenticated users only
 export const getAdminId = createHandler(authService.getAdminId, 200);
 
-// Login has custom cookie handling, keep it as-is
+// Login issues both access and refresh cookies
 export const login = async (req, res, next) => {
   try {
-    const { token, cookieOptions, user } = await authService.login(req);
-    res.cookie("access_token", token, cookieOptions);
+    const { accessToken, refreshToken, accessCookieOptions, refreshCookieOptions, user } =
+      await authService.login(req);
+    res.cookie("access_token", accessToken, accessCookieOptions);
+    res.cookie("refresh_token", refreshToken, refreshCookieOptions);
     res.status(200).json(user);
   } catch (error) {
     next(error);
   }
 };
 
-// Logout has custom cookie clearing, keep it as-is
+// Logout clears both cookies
 export const logout = async (req, res, next) => {
   try {
     const { cookieOptions, message } = await authService.logout();
     res.clearCookie("access_token", cookieOptions);
+    res.clearCookie("refresh_token", cookieOptions);
     res.status(200).json({ message });
+  } catch (error) {
+    next(error);
+  }
+};
+
+// Refresh validates the refresh cookie and issues a new access cookie
+export const refresh = async (req, res, next) => {
+  try {
+    const { accessToken, accessCookieOptions } = await authService.refresh(req);
+    res.cookie("access_token", accessToken, accessCookieOptions);
+    res.status(200).json({ message: "Token refreshed" });
   } catch (error) {
     next(error);
   }

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,11 +1,12 @@
 import express from "express";
-import { register, login, logout, getAdminId } from "../controllers/auth.js";
+import { register, login, logout, refresh, getAdminId } from "../controllers/auth.js";
 import { verifyAdmin, verifyToken } from "../utils/verifyToken.js";
 const router = express.Router();
 
 // Public routes
 router.post("/login", login);
 router.post("/logout", logout);
+router.post("/refresh", refresh);
 
 // Auth routes — any verified user
 const authRouter = express.Router();

--- a/server/services/authService.js
+++ b/server/services/authService.js
@@ -6,18 +6,15 @@ import { templatePhone } from "../utils/templates.js";
 
 const COOKIE_DOMAIN = process.env.COOKIE_DOMAIN;
 const isProd = () => process.env.NODE_ENV === "production";
+const jwtRefreshSecret = () => process.env.JWT_REFRESH || process.env.JWT;
 
-/**
- * Builds cookie options shared by login and logout.
- * @param {boolean} withMaxAge - include maxAge (true for login, false for logout)
- */
-const buildCookieOptions = (withMaxAge = false) => {
+const buildCookieOptions = (maxAge = null) => {
   const options = {
     httpOnly: true,
     secure: isProd(),
     sameSite: isProd() ? "none" : "lax",
     path: "/",
-    ...(withMaxAge && { maxAge: 24 * 60 * 60 * 1000 }),
+    ...(maxAge && { maxAge }),
   };
   if (isProd()) options.domain = COOKIE_DOMAIN;
   return options;
@@ -90,19 +87,19 @@ const login = async (req) => {
   const isPassword = await bcrypt.compare(password, user.password);
   if (!isPassword) throw createError(401, "Invalid credentials");
 
-  const token = jwt.sign({ id: user._id, isAdmin: user.isAdmin }, process.env.JWT, {
-    expiresIn: "24h",
+  const accessToken = jwt.sign({ id: user._id, isAdmin: user.isAdmin }, process.env.JWT, {
+    expiresIn: "15m",
+  });
+  const refreshToken = jwt.sign({ id: user._id }, jwtRefreshSecret(), {
+    expiresIn: "7d",
   });
 
-  const cookieOptions = buildCookieOptions(true);
-
   return {
-    token,
-    cookieOptions,
-    user: {
-      _id: user._id,
-      isAdmin: user.isAdmin,
-    },
+    accessToken,
+    refreshToken,
+    accessCookieOptions: buildCookieOptions(15 * 60 * 1000),
+    refreshCookieOptions: buildCookieOptions(7 * 24 * 60 * 60 * 1000),
+    user: { _id: user._id, isAdmin: user.isAdmin },
   };
 };
 
@@ -110,6 +107,30 @@ const logout = async () => {
   return {
     cookieOptions: buildCookieOptions(),
     message: "User has been logged out successfully",
+  };
+};
+
+const refresh = async (req) => {
+  const token = req.cookies.refresh_token;
+  if (!token) throw createError(401, "No refresh token provided");
+
+  let decoded;
+  try {
+    decoded = jwt.verify(token, jwtRefreshSecret());
+  } catch (_err) {
+    throw createError(403, "Invalid or expired refresh token");
+  }
+
+  const user = await User.findById(decoded.id).select("isAdmin");
+  if (!user) throw createError(403, "User not found");
+
+  const accessToken = jwt.sign({ id: user._id, isAdmin: user.isAdmin }, process.env.JWT, {
+    expiresIn: "15m",
+  });
+
+  return {
+    accessToken,
+    accessCookieOptions: buildCookieOptions(15 * 60 * 1000),
   };
 };
 
@@ -123,6 +144,7 @@ const authService = {
   register,
   login,
   logout,
+  refresh,
   getAdminId,
 };
 


### PR DESCRIPTION
## What
Implements the two-token auth pattern to keep users logged in without prompting for credentials every 15 minutes.

### Server
- **`authService.login`** now issues two cookies on login:
  - `access_token` — short-lived (15 min), same JWT format as before
  - `refresh_token` — long-lived (7 days), signed with `JWT_REFRESH` env var (falls back to `JWT` if not set)
- **`authService.refresh`** — validates the `refresh_token` cookie and issues a fresh `access_token` cookie
- **`POST /api/auth/refresh`** — new public route (no auth middleware needed)
- **`logout`** now clears both cookies

### Client
- **`axiosConfig.js`** interceptor upgraded:
  - On 401, silently calls `POST /auth/refresh` before redirecting
  - If refresh succeeds, retries the original request transparently
  - Failed-queue pattern prevents duplicate refresh calls when multiple requests 401 simultaneously
  - If refresh itself fails (expired/invalid), clears auth and redirects to home

## Why
Closes #267

## Test plan
- [ ] Login → both `access_token` and `refresh_token` cookies are set
- [ ] After 15 min (or manually clear `access_token`), make an API call → refresh fires silently, original request retries
- [ ] After 7 days (or manually clear both cookies), make an API call → user redirected to login
- [ ] Logout → both cookies cleared
- [ ] All 33 server tests pass ✅
- [ ] `JWT_REFRESH` not set → falls back to `JWT` secret (backward-compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)