### PR TITLE
fix: replace hand-rolled cache object with documented InMemoryCache (closes #273)

### DIFF
--- a/server/services/dashboardService.js
+++ b/server/services/dashboardService.js
@@ -4,6 +4,7 @@ import Service from "../models/Service.js";
 import Appointment from "../models/Appointment.js";
 import Message from "../models/Message.js";
 import Review from "../models/Review.js";
+import { InMemoryCache } from "../utils/cache.js";
 
 /**
  * Returns a monthly aggregation pipeline for a Mongoose model since a given date.
@@ -22,16 +23,19 @@ const getMonthlyTrend = (Model, since) =>
     { $sort: { "_id.year": 1, "_id.month": 1 } },
   ]);
 
-let _cache = { data: null, expiresAt: 0 };
 const CACHE_TTL_MS = 60_000; // 1 minute
+// See server/utils/cache.js for the single-process constraint documentation.
+const dashboardCache = new InMemoryCache(CACHE_TTL_MS);
+const CACHE_KEY = "dashboardStats";
 
 /**
- * Get comprehensive dashboard statistics
+ * Get comprehensive dashboard statistics.
  * Results are cached for 60 seconds to reduce DB load.
  * @returns {Object} Dashboard statistics including counts, recent data, and trends
  */
 const getDashboardStats = async () => {
-  if (_cache.data && Date.now() < _cache.expiresAt) return _cache.data;
+  const cached = dashboardCache.get(CACHE_KEY);
+  if (cached) return cached;
 
   // Get total counts
   const [totalUsers, totalCars, totalServices, totalAppointments, totalMessages, totalReviews] =
@@ -143,7 +147,7 @@ const getDashboardStats = async () => {
     },
     topServices,
   };
-  _cache = { data, expiresAt: Date.now() + CACHE_TTL_MS };
+  dashboardCache.set(CACHE_KEY, data);
   return data;
 };
 

--- a/server/utils/cache.js
+++ b/server/utils/cache.js
@@ -1,0 +1,40 @@
+/**
+ * Simple in-process TTL cache.
+ *
+ * ⚠️  SINGLE-PROCESS ONLY — In a multi-process deployment (PM2 cluster,
+ * serverless with cold starts) each worker maintains its own independent
+ * copy. Upgrade to a shared cache (Redis via `ioredis`, or Upstash for
+ * serverless) when horizontal scaling is needed.
+ *
+ * Usage:
+ *   const cache = new InMemoryCache(ttlMs);
+ *   const hit = cache.get(key);          // null on miss
+ *   cache.set(key, value);
+ *   cache.delete(key);
+ */
+export class InMemoryCache {
+  #store = new Map();
+  #ttlMs;
+
+  constructor(ttlMs) {
+    this.#ttlMs = ttlMs;
+  }
+
+  get(key) {
+    const entry = this.#store.get(key);
+    if (!entry) return null;
+    if (Date.now() > entry.expiresAt) {
+      this.#store.delete(key);
+      return null;
+    }
+    return entry.value;
+  }
+
+  set(key, value) {
+    this.#store.set(key, { value, expiresAt: Date.now() + this.#ttlMs });
+  }
+
+  delete(key) {
+    this.#store.delete(key);
+  }
+}


### PR DESCRIPTION
## What
Extracts the dashboard cache into a reusable `InMemoryCache` class in `server/utils/cache.js`. The class carries a prominent JSDoc warning that it is **single-process only** and documents the Redis upgrade path.

`dashboardService.js` drops the bare `_cache = { data, expiresAt }` pattern and uses `new InMemoryCache(CACHE_TTL_MS)` with `.get()` / `.set()` instead — identical runtime behaviour, but the constraint is now visible in the code and the interface is clean enough to swap for a Redis adapter without touching the service.

```js
// Before
let _cache = { data: null, expiresAt: 0 };
if (_cache.data && Date.now() < _cache.expiresAt) return _cache.data;
_cache = { data, expiresAt: Date.now() + CACHE_TTL_MS };

// After
const dashboardCache = new InMemoryCache(CACHE_TTL_MS);
const cached = dashboardCache.get(CACHE_KEY);
if (cached) return cached;
dashboardCache.set(CACHE_KEY, data);
```

## Why
Closes #273

## Test plan
- [ ] `GET /api/dashboard/stats` returns data correctly
- [ ] Second call within 60 s is served from cache (no DB queries)
- [ ] All 33 server tests pass ✅
- [ ] Review `server/utils/cache.js` — single-process warning is visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)