### PR TITLE
feat: add email notifications for appointment lifecycle events (closes #123)

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -18,5 +18,22 @@ CLIENT_URL=https://your-client-domain.com
 # Port the Express server listens on (optional, defaults to 8800)
 PORT=8800
 
+# ── Email (Nodemailer) ────────────────────────────────────────────────────────
+# Leave SMTP_HOST unset to disable email sending entirely (graceful no-op).
+# Works with any SMTP provider: Gmail, SendGrid SMTP relay, Resend SMTP, etc.
+#
+# Gmail example (use an App Password if 2FA is enabled):
+#   SMTP_HOST=smtp.gmail.com  SMTP_PORT=587
+#   SMTP_USER=you@gmail.com   SMTP_PASS=your-app-password
+#
+# SendGrid SMTP relay:
+#   SMTP_HOST=smtp.sendgrid.net  SMTP_PORT=587
+#   SMTP_USER=apikey             SMTP_PASS=SG.your-api-key
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USER=
+SMTP_PASS=
+EMAIL_FROM="Garage770" <no-reply@garage770.com>
+
 # Set to "production" in deployed environments; anything else is treated as dev
 NODE_ENV=development

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -19,6 +19,7 @@
         "express-rate-limit": "^8.3.1",
         "jsonwebtoken": "^9.0.0",
         "mongoose": "^6.9.0",
+        "nodemailer": "^8.0.10",
         "nodemon": "^2.0.20",
         "uuid": "^14.0.0"
       },
@@ -4216,6 +4217,15 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.10.tgz",
+      "integrity": "sha512-BLFuSth7QtHOkBzyqTehWWyub0NTRDuK2Q2SQfnGLsrJnzyU+Yeh4WpV1eZGuARFj1xQJHIdnTuJZLP+b9R1GQ==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/nodemon": {
       "version": "2.0.20",

--- a/server/package.json
+++ b/server/package.json
@@ -29,6 +29,7 @@
     "express-rate-limit": "^8.3.1",
     "jsonwebtoken": "^9.0.0",
     "mongoose": "^6.9.0",
+    "nodemailer": "^8.0.10",
     "nodemon": "^2.0.20",
     "uuid": "^14.0.0"
   },

--- a/server/services/appointmentService.js
+++ b/server/services/appointmentService.js
@@ -2,6 +2,10 @@ import Appointment from "../models/Appointment.js";
 import { templatePhone } from "../utils/templates.js";
 import { createError } from "../utils/error.js";
 import { pickAllowed, getPaginationParams } from "../utils/queryHelpers.js";
+import {
+  sendAppointmentConfirmation,
+  sendStatusUpdate,
+} from "./emailService.js";
 
 const ALLOWED_APPOINTMENT_CREATE_FIELDS = [
   "clientName",
@@ -30,6 +34,7 @@ const createAppointment = async (req) => {
 
   const newAppointment = new Appointment({ ...safeBody, phone: formattedPhone });
   const savedAppointment = await newAppointment.save();
+  sendAppointmentConfirmation(savedAppointment); // fire-and-forget
   return savedAppointment;
 };
 
@@ -73,6 +78,7 @@ const updateAppointmentStatus = async (req) => {
     { new: true }
   );
   if (!updatedAppointment) throw createError(404, "Appointment not found");
+  sendStatusUpdate(updatedAppointment); // fire-and-forget
   return updatedAppointment;
 };
 

--- a/server/services/appointmentService.js
+++ b/server/services/appointmentService.js
@@ -2,10 +2,7 @@ import Appointment from "../models/Appointment.js";
 import { templatePhone } from "../utils/templates.js";
 import { createError } from "../utils/error.js";
 import { pickAllowed, getPaginationParams } from "../utils/queryHelpers.js";
-import {
-  sendAppointmentConfirmation,
-  sendStatusUpdate,
-} from "./emailService.js";
+import { sendAppointmentConfirmation, sendStatusUpdate } from "./emailService.js";
 
 const ALLOWED_APPOINTMENT_CREATE_FIELDS = [
   "clientName",

--- a/server/services/emailService.js
+++ b/server/services/emailService.js
@@ -66,11 +66,12 @@ export const sendStatusUpdate = async (appointment) => {
   const transporter = createTransporter();
   if (!transporter) return;
 
-  const statusLabel = {
-    confirmed: "Confirmed ✅",
-    cancelled: "Cancelled ❌",
-    pending: "Pending ⏳",
-  }[appointment.status] ?? appointment.status;
+  const statusLabel =
+    {
+      confirmed: "Confirmed ✅",
+      cancelled: "Cancelled ❌",
+      pending: "Pending ⏳",
+    }[appointment.status] ?? appointment.status;
 
   try {
     await transporter.sendMail({

--- a/server/services/emailService.js
+++ b/server/services/emailService.js
@@ -1,0 +1,97 @@
+import nodemailer from "nodemailer";
+
+/**
+ * Returns a configured transporter, or null if SMTP is not set up.
+ * All env vars are read at call-time so tests can set them in beforeAll.
+ */
+const createTransporter = () => {
+  const { SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS } = process.env;
+  if (!SMTP_HOST || !SMTP_USER) return null;
+
+  return nodemailer.createTransport({
+    host: SMTP_HOST,
+    port: Number(SMTP_PORT) || 587,
+    secure: Number(SMTP_PORT) === 465,
+    auth: { user: SMTP_USER, pass: SMTP_PASS },
+  });
+};
+
+const FROM = () =>
+  process.env.EMAIL_FROM || `"Garage770" <${process.env.SMTP_USER || "no-reply@garage770.com"}>`;
+
+const formatDate = (date) =>
+  new Date(date).toLocaleDateString("en-US", {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+/**
+ * Sends a booking confirmation to the customer after createAppointment.
+ * Fire-and-forget — errors are logged but never thrown.
+ */
+export const sendAppointmentConfirmation = async (appointment) => {
+  const transporter = createTransporter();
+  if (!transporter) return;
+
+  try {
+    await transporter.sendMail({
+      from: FROM(),
+      to: appointment.email,
+      subject: "Your Garage770 Appointment is Confirmed",
+      html: `
+        <h2>Appointment Confirmed</h2>
+        <p>Hi ${appointment.clientName},</p>
+        <p>Your appointment has been successfully booked at <strong>Garage770</strong>.</p>
+        <table>
+          <tr><td><strong>Date:</strong></td><td>${formatDate(appointment.date)}</td></tr>
+          <tr><td><strong>Time:</strong></td><td>${appointment.time}</td></tr>
+          ${appointment.notes ? `<tr><td><strong>Notes:</strong></td><td>${appointment.notes}</td></tr>` : ""}
+        </table>
+        <p>We will be in touch if anything changes. See you soon!</p>
+        <p>— The Garage770 Team</p>
+      `,
+    });
+  } catch (err) {
+    console.error("[emailService] Failed to send confirmation:", err.message);
+  }
+};
+
+/**
+ * Notifies the customer when an admin updates the appointment status.
+ * Fire-and-forget — errors are logged but never thrown.
+ */
+export const sendStatusUpdate = async (appointment) => {
+  const transporter = createTransporter();
+  if (!transporter) return;
+
+  const statusLabel = {
+    confirmed: "Confirmed ✅",
+    cancelled: "Cancelled ❌",
+    pending: "Pending ⏳",
+  }[appointment.status] ?? appointment.status;
+
+  try {
+    await transporter.sendMail({
+      from: FROM(),
+      to: appointment.email,
+      subject: `Garage770 Appointment ${statusLabel}`,
+      html: `
+        <h2>Appointment Status Updated</h2>
+        <p>Hi ${appointment.clientName},</p>
+        <p>Your appointment on <strong>${formatDate(appointment.date)}</strong> at
+           <strong>${appointment.time}</strong> has been updated to:
+           <strong>${statusLabel}</strong>.</p>
+        ${
+          appointment.status === "cancelled"
+            ? "<p>If you believe this is an error, please contact us.</p>"
+            : ""
+        }
+        <p>— The Garage770 Team</p>
+      `,
+    });
+  } catch (err) {
+    console.error("[emailService] Failed to send status update:", err.message);
+  }
+};


### PR DESCRIPTION
## What
Adds transactional email notifications using **Nodemailer** — SMTP-agnostic, zero API key required, works with Gmail, SendGrid SMTP relay, Resend, Mailgun, or any SMTP server.

**`server/services/emailService.js`** — two exported helpers:
- `sendAppointmentConfirmation(appointment)` — sends a booking confirmation to the customer's email after `createAppointment` succeeds
- `sendStatusUpdate(appointment)` — notifies the customer when an admin updates the appointment status (confirmed ✅ / cancelled ❌ / pending ⏳)

Both functions are **fire-and-forget**: they return immediately, log errors to stderr, and never throw — so a misconfigured SMTP server cannot break the API response. When `SMTP_HOST` or `SMTP_USER` is not set in the environment, both functions are silent no-ops (the transporter is never created).

**`server/.env.example`** updated with all five SMTP variables and commented provider examples (Gmail App Password, SendGrid SMTP relay).

## Why
Closes #123

## Configuration
Set these env vars on your server to activate email sending:
```
SMTP_HOST=smtp.gmail.com     # or smtp.sendgrid.net, etc.
SMTP_PORT=587
SMTP_USER=you@example.com
SMTP_PASS=your-password-or-api-key
EMAIL_FROM="Garage770" <no-reply@garage770.com>
```
Leave `SMTP_HOST` unset to keep email disabled (default / safe for dev).

## Test plan
- [ ] Create an appointment via the public form → confirmation email arrives at `appointment.email`
- [ ] Admin changes status to "confirmed" → status update email arrives
- [ ] Admin changes status to "cancelled" → cancellation email arrives
- [ ] `SMTP_HOST` unset → no email sent, no error, API responds normally
- [ ] SMTP misconfigured → error logged to stderr, API still responds 201/200
- [ ] All 33 server tests pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)