### PR TITLE
fix: frontend review pass 4 — aria-invalid bug, form reset on error, broken select values

### DIFF
--- a/client/src/components/form/FormSelect.jsx
+++ b/client/src/components/form/FormSelect.jsx
@@ -6,11 +6,15 @@ export default function FormSelect({ name, options, handleChange, value }) {
       <span>{name}</span>
       <select name={name} onChange={handleChange} value={value || ""}>
         <option value="">{name}</option>
-        {options?.map((option, index) => (
-          <option key={index} value={name === "status" ? option?.value : option?._id}>
-            {name === "status" ? option?.label : option?.username}
-          </option>
-        ))}
+        {options?.map((option) => {
+          const val = option?.value ?? option?._id;
+          const label = option?.label ?? option?.username;
+          return (
+            <option key={val} value={val}>
+              {label}
+            </option>
+          );
+        })}
       </select>
     </label>
   );

--- a/client/src/pages/appointments/hooks/useAppointmentsPage.js
+++ b/client/src/pages/appointments/hooks/useAppointmentsPage.js
@@ -25,11 +25,11 @@ export function useAppointmentsPage() {
   const stats = useAppointmentStats(appointments);
   const appointmentFilters = useAppointmentFilters(appointments);
 
-  const handleSubmit = (e) => {
+  const handleSubmit = useCallback(async (e) => {
     e.preventDefault();
-    storeCreate(appointmentForm.prepareSubmitData());
-    appointmentForm.resetForm();
-  };
+    const created = await storeCreate(appointmentForm.prepareSubmitData());
+    if (created) appointmentForm.resetForm();
+  }, [storeCreate, appointmentForm]);
 
   const handleStatusChange = useCallback(
     (id, newStatus) => storeUpdate({ id, data: { status: newStatus } }),

--- a/client/src/pages/appointments/hooks/useAppointmentsPage.js
+++ b/client/src/pages/appointments/hooks/useAppointmentsPage.js
@@ -25,11 +25,14 @@ export function useAppointmentsPage() {
   const stats = useAppointmentStats(appointments);
   const appointmentFilters = useAppointmentFilters(appointments);
 
-  const handleSubmit = useCallback(async (e) => {
-    e.preventDefault();
-    const created = await storeCreate(appointmentForm.prepareSubmitData());
-    if (created) appointmentForm.resetForm();
-  }, [storeCreate, appointmentForm]);
+  const handleSubmit = useCallback(
+    async (e) => {
+      e.preventDefault();
+      const created = await storeCreate(appointmentForm.prepareSubmitData());
+      if (created) appointmentForm.resetForm();
+    },
+    [storeCreate, appointmentForm]
+  );
 
   const handleStatusChange = useCallback(
     (id, newStatus) => storeUpdate({ id, data: { status: newStatus } }),

--- a/client/src/validation/valid.js
+++ b/client/src/validation/valid.js
@@ -41,6 +41,7 @@ const VALIDATORS = {
   numberPlate: validCar,
 };
 
-const valid = (data, type) => VALIDATORS[type]?.(data) ?? false;
+// Unknown field types (username, title, km…) have no regex — treat as valid
+const valid = (data, type) => VALIDATORS[type]?.(data) ?? true;
 
 export { valid, validCar, validPhone, validPass, validEmail, validUserIsExist, inputType };


### PR DESCRIPTION
## Summary

- **🔴 `valid.js`** — The fallback `?? false` meant any field whose name isn't `email`, `password`, `phone`, or `numberPlate` (i.e. `username`, `title`, `km`, `brand`, etc.) evaluated as invalid after the first form submission, setting `aria-invalid="true"` on perfectly valid inputs. Screen readers announced every text field as invalid. Changed to `?? true` so unknown field types are treated as always valid.

- **🟡 `useAppointmentsPage`** — `handleSubmit` called `resetForm()` synchronously *before* `storeCreate` resolved. If the API returned an error, the form was already cleared and the user's input was lost. Made the handler `async`, awaits the store action, and only resets on success. Also wrapped in `useCallback` to prevent re-creating the function on every render.

- **🟡 `FormSelect`** — The `to` recipient select in **CreateMessage was always submitting `undefined`** as the selected user. `usersToOptions()` returns `{ value, label }` objects, but the old code branched on `name === "status"` and read `option._id` for non-status selects — which is `undefined` in the `{ value, label }` shape. Unified to `option?.value ?? option?._id` so both shapes work. Also replaced array index with the stable option value as key.

## Test plan

- [ ] Open any edit form (Edit User, Edit Car, Create Car) → fill in all fields → submit → no field should show `aria-invalid` if it has a valid value
- [ ] On the Appointments page, fill the booking form → submit while the network is slow/fails → form data should be preserved
- [ ] Open Create Message as admin → select a recipient from the dropdown → submit → message should arrive with the correct `to` user (not `undefined`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)