### PR TITLE
fix: frontend review pass 5 — security, a11y, stale state, Zustand selector

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -38,7 +38,9 @@ function App() {
         </a>
         <Header />
         <main id="main-content">
-          <Suspense fallback={<div className="page-loader" role="status" aria-label="Loading page" />}>
+          <Suspense
+            fallback={<div className="page-loader" role="status" aria-label="Loading page" />}
+          >
             <Routes>
               <Route path="/" element={<PageLanding />} />
               {PRIVATE_ROUTES.map(({ path, Component }) => (

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -38,7 +38,7 @@ function App() {
         </a>
         <Header />
         <main id="main-content">
-          <Suspense fallback={<div className="page-loader" />}>
+          <Suspense fallback={<div className="page-loader" role="status" aria-label="Loading page" />}>
             <Routes>
               <Route path="/" element={<PageLanding />} />
               {PRIVATE_ROUTES.map(({ path, Component }) => (

--- a/client/src/components/Toast.jsx
+++ b/client/src/components/Toast.jsx
@@ -2,7 +2,10 @@ import { useToastStore } from "../stores/toastStore";
 import "./toast.css";
 
 export default function Toast() {
-  const { message, type, visible, hide } = useToastStore();
+  const message = useToastStore((s) => s.message);
+  const type    = useToastStore((s) => s.type);
+  const visible = useToastStore((s) => s.visible);
+  const hide    = useToastStore((s) => s.hide);
   if (!visible) return null;
 
   return (

--- a/client/src/components/Toast.jsx
+++ b/client/src/components/Toast.jsx
@@ -3,9 +3,9 @@ import "./toast.css";
 
 export default function Toast() {
   const message = useToastStore((s) => s.message);
-  const type    = useToastStore((s) => s.type);
+  const type = useToastStore((s) => s.type);
   const visible = useToastStore((s) => s.visible);
-  const hide    = useToastStore((s) => s.hide);
+  const hide = useToastStore((s) => s.hide);
   if (!visible) return null;
 
   return (

--- a/client/src/components/landing/address/AddressLink.jsx
+++ b/client/src/components/landing/address/AddressLink.jsx
@@ -2,7 +2,7 @@ import "./address.css";
 
 const AddressLink = ({ address }) => {
   return (
-    <a className="address" target="_blank" href={"https://maps.google.com/?q=" + address}>
+    <a className="address" target="_blank" rel="noopener noreferrer" href={"https://maps.google.com/?q=" + address}>
       {address}
     </a>
   );

--- a/client/src/components/landing/address/AddressLink.jsx
+++ b/client/src/components/landing/address/AddressLink.jsx
@@ -2,7 +2,12 @@ import "./address.css";
 
 const AddressLink = ({ address }) => {
   return (
-    <a className="address" target="_blank" rel="noopener noreferrer" href={"https://maps.google.com/?q=" + address}>
+    <a
+      className="address"
+      target="_blank"
+      rel="noopener noreferrer"
+      href={"https://maps.google.com/?q=" + address}
+    >
       {address}
     </a>
   );

--- a/client/src/pages/signup/Signup.jsx
+++ b/client/src/pages/signup/Signup.jsx
@@ -4,10 +4,28 @@ import { useAuthStore } from "../../stores/authStore";
 import "./signup.css";
 
 const FIELDS = [
-  { name: "username", type: "text",     label: "Username",                      placeholder: "Username",              autoComplete: "username" },
-  { name: "email",    type: "email",    label: "Email",                         placeholder: "Email",                 autoComplete: "email" },
-  { name: "phone",    type: "tel",      label: "Phone",                         placeholder: "e.g. 050-123-4567",     autoComplete: "tel" },
-  { name: "password", type: "password", label: "Password",                      placeholder: "Password",              autoComplete: "new-password" },
+  {
+    name: "username",
+    type: "text",
+    label: "Username",
+    placeholder: "Username",
+    autoComplete: "username",
+  },
+  { name: "email", type: "email", label: "Email", placeholder: "Email", autoComplete: "email" },
+  {
+    name: "phone",
+    type: "tel",
+    label: "Phone",
+    placeholder: "e.g. 050-123-4567",
+    autoComplete: "tel",
+  },
+  {
+    name: "password",
+    type: "password",
+    label: "Password",
+    placeholder: "Password",
+    autoComplete: "new-password",
+  },
 ];
 
 const Signup = () => {

--- a/client/src/pages/signup/Signup.jsx
+++ b/client/src/pages/signup/Signup.jsx
@@ -1,13 +1,13 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { useAuthStore } from "../../stores/authStore";
 import "./signup.css";
 
 const FIELDS = [
-  { name: "username", type: "text", placeholder: "Username", autoComplete: "username" },
-  { name: "email", type: "email", placeholder: "Email", autoComplete: "email" },
-  { name: "phone", type: "tel", placeholder: "Phone (e.g. 050-123-4567)", autoComplete: "tel" },
-  { name: "password", type: "password", placeholder: "Password", autoComplete: "new-password" },
+  { name: "username", type: "text",     label: "Username",                      placeholder: "Username",              autoComplete: "username" },
+  { name: "email",    type: "email",    label: "Email",                         placeholder: "Email",                 autoComplete: "email" },
+  { name: "phone",    type: "tel",      label: "Phone",                         placeholder: "e.g. 050-123-4567",     autoComplete: "tel" },
+  { name: "password", type: "password", label: "Password",                      placeholder: "Password",              autoComplete: "new-password" },
 ];
 
 const Signup = () => {
@@ -24,6 +24,9 @@ const Signup = () => {
   const message = useAuthStore((s) => s.message);
   const reset = useAuthStore((s) => s.reset);
   const navigate = useNavigate();
+
+  // Reset auth flags on unmount so re-visiting doesn't show stale success screen
+  useEffect(() => () => reset(), [reset]);
 
   const handleChange = (e) => {
     setFormData((prev) => ({ ...prev, [e.target.name]: e.target.value }));
@@ -58,18 +61,21 @@ const Signup = () => {
         <p className="signup-subtitle">Join Garage770 and manage your vehicle services</p>
 
         <form className="signup-form" onSubmit={handleSubmit} noValidate>
-          {FIELDS.map(({ name, type, placeholder, autoComplete }) => (
-            <input
-              key={name}
-              className="signup-input"
-              type={type}
-              name={name}
-              placeholder={placeholder}
-              autoComplete={autoComplete}
-              value={formData[name]}
-              onChange={handleChange}
-              required
-            />
+          {FIELDS.map(({ name, type, label, placeholder, autoComplete }) => (
+            <label key={name} className="signup-field">
+              <span className="sr-only">{label}</span>
+              <input
+                id={`signup-${name}`}
+                className="signup-input"
+                type={type}
+                name={name}
+                placeholder={placeholder}
+                autoComplete={autoComplete}
+                value={formData[name]}
+                onChange={handleChange}
+                required
+              />
+            </label>
           ))}
 
           {isError && <p className="signup-error">{message}</p>}


### PR DESCRIPTION
## Summary

- **🔴 AddressLink** — Google Maps link used `target="_blank"` without `rel="noopener noreferrer"`, exposing the page to `window.opener` tab-napping attacks.

- **🟡 Signup — missing labels** — All four form inputs (`username`, `email`, `phone`, `password`) had no `<label>` elements. Screen readers could not identify the purpose of each field. Wrapped each input in a `<label>` with `sr-only` visible text.

- **🟡 Signup — stale `isSuccess`** — Navigating to `/signup` after a successful registration (without a page reload) showed the "Account Created!" success screen instead of the form. Added a cleanup-only `useEffect(() => () => reset(), [reset])` so auth flags are cleared when the user leaves the page.

- **🟡 Toast** — `useToastStore()` was called without a selector, subscribing the component to every store field. Replaced with four granular `(s) => s.field` selectors so Toast only re-renders when its own fields change.

- **🟡 App** — The `Suspense` fallback `<div>` was missing `role="status"` and `aria-label="Loading page"` that existed in the previous version. Screen readers would silently skip the loading indicator. Restored both attributes.

## Test plan

- [ ] Click the garage address link → new tab opens without referrer / opener access
- [ ] Tab through the signup form with a screen reader — each field should announce its label
- [ ] Sign up successfully → click Back → navigate to `/signup` again → should show the form, not the success screen
- [ ] Trigger a toast notification → inspect DOM — Toast should not re-render when unrelated store fields change
- [ ] Navigate between lazy-loaded pages → screen reader should announce "Loading page" during transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)