### PR TITLE
fix: validate JWT_REFRESH at startup and document in .env.example (closes #305)

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,5 +1,9 @@
-# JWT signing secret — use a long random string in production
+# JWT signing secret for access tokens — use a long random string in production
 JWT=your_jwt_secret_here
+
+# Separate secret for signing refresh tokens — MUST differ from JWT
+# Generate with: node -e "console.log(require('crypto').randomBytes(64).toString('hex'))"
+JWT_REFRESH=your_refresh_jwt_secret_here
 
 # MongoDB connection string
 MONGO=mongodb+srv://<user>:<password>@<cluster>/<database>

--- a/server/index.js
+++ b/server/index.js
@@ -10,6 +10,11 @@ if (!process.env.JWT) {
   process.exit(1);
 }
 
+if (!process.env.JWT_REFRESH) {
+  console.error("FATAL: JWT_REFRESH secret is not defined — refresh tokens require a separate secret");
+  process.exit(1);
+}
+
 if (!process.env.ANTHROPIC_API_KEY) {
   console.warn("WARNING: ANTHROPIC_API_KEY is not set — /api/agent endpoints will be unavailable");
 }

--- a/server/index.js
+++ b/server/index.js
@@ -11,7 +11,9 @@ if (!process.env.JWT) {
 }
 
 if (!process.env.JWT_REFRESH) {
-  console.error("FATAL: JWT_REFRESH secret is not defined — refresh tokens require a separate secret");
+  console.error(
+    "FATAL: JWT_REFRESH secret is not defined — refresh tokens require a separate secret"
+  );
   process.exit(1);
 }
 


### PR DESCRIPTION
## What
Adds `JWT_REFRESH` to `server/.env.example` with generation instructions, and adds a fatal startup check in `server/index.js` that mirrors the existing `JWT` check. When `JWT_REFRESH` is unset the server now exits rather than silently falling back to signing refresh tokens with the access-token secret.

## Why
Closes #305

## Test plan
- [ ] Server starts normally when `JWT_REFRESH` is set
- [ ] Server exits with a clear error message when `JWT_REFRESH` is missing from env
- [ ] All 33 existing tests pass (no test uses `index.js`, so they are unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)