### PR TITLE
fix: add dedicated signup rate limiter (5/hour) for POST /auth/signup (closes #306)

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -48,6 +48,14 @@ const publicWriteLimiter = rateLimit({
   legacyHeaders: false,
 });
 
+const signupLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  max: 5,
+  message: { message: "Too many registration attempts, please try again later" },
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
 const app = express();
 
 app.use(logger);
@@ -65,6 +73,7 @@ app.use(
   })
 );
 
+app.post("/api/auth/signup", signupLimiter);
 app.use("/api/auth", authLimiter, authRoute);
 app.use("/api/users", publicLimiter, usersRoute);
 app.use("/api/cars", publicLimiter, carsRoute);


### PR DESCRIPTION
## What
Adds a `signupLimiter` (5 requests per hour per IP) applied specifically to `POST /api/auth/signup` before the broader `authLimiter`. The new limiter uses the same pre-route pattern already in place for contacts and appointments (`app.post(path, limiter)` stacked before `app.use(path, router)`).

## Why
Closes #306

## Test plan
- [ ] Sixth signup attempt from the same IP within an hour receives 429 with "Too many registration attempts"
- [ ] Login (`POST /api/auth/login`) is unaffected by the signup budget
- [ ] All 33 existing server tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)