### PR TITLE
fix: wire auditAdmin to services mutating routes (closes #307)

### DIFF
--- a/server/routes/services.js
+++ b/server/routes/services.js
@@ -10,6 +10,7 @@ import {
   getServicesByUser,
 } from "../controllers/service.js";
 import { verifyAdmin, verifyUser } from "../utils/verifyToken.js";
+import { auditAdmin } from "../middleware/audit.js";
 const router = express.Router();
 
 // Admin routes
@@ -17,9 +18,9 @@ const adminRouter = express.Router();
 adminRouter.use(verifyAdmin);
 adminRouter.get("/populate", getServicesByType);
 adminRouter.get("/", getServices);
-adminRouter.post("/:carId", createService);
-adminRouter.put("/:id", updateService);
-adminRouter.delete("/:id", deleteService);
+adminRouter.post("/:carId", auditAdmin("CREATE_SERVICE", "Service"), createService);
+adminRouter.put("/:id", auditAdmin("UPDATE_SERVICE", "Service"), updateService);
+adminRouter.delete("/:id", auditAdmin("DELETE_SERVICE", "Service"), deleteService);
 
 // User routes
 const userRouter = express.Router();


### PR DESCRIPTION
## What
Imports `auditAdmin` middleware into `server/routes/services.js` and wires it to the three admin mutating routes — `createService`, `updateService`, and `deleteService` — using the same pattern already applied to users, cars, and appointments.

## Why
Closes #307

Services carry `price` and `paid` fields; financial admin actions now appear in the audit log alongside user/car/appointment mutations.

## Test plan
- [ ] Creating, updating, or deleting a service as admin writes an `AuditLog` entry
- [ ] Read-only service routes (GET) produce no audit entry
- [ ] All 33 existing server tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)