### PR TITLE
feat: return total count from list endpoints and update client to handle new shape (closes #309)

### DIFF
--- a/client/src/api/crudOperations.js
+++ b/client/src/api/crudOperations.js
@@ -12,7 +12,8 @@ export const createCrudOperations = (baseUrl) => ({
    */
   getAll: async () => {
     const response = await axios.get(baseUrl, { params: { limit: 5000 } });
-    return response.data;
+    const payload = response.data;
+    return Array.isArray(payload) ? payload : payload.data;
   },
 
   /**

--- a/client/src/stores/appointmentsStore.js
+++ b/client/src/stores/appointmentsStore.js
@@ -12,8 +12,9 @@ export const useAppointmentsStore = create((set) => ({
   fetchAppointments: async () => {
     set({ isLoading: true });
     try {
-      const { data } = await axios.get(API_URL_APPOINTMENTS);
-      set({ appointments: data, isLoading: false });
+      const { data: payload } = await axios.get(API_URL_APPOINTMENTS);
+      const appointments = Array.isArray(payload) ? payload : payload.data;
+      set({ appointments, isLoading: false });
     } catch (err) {
       setErr(set, err);
     }

--- a/client/src/stores/userStore.js
+++ b/client/src/stores/userStore.js
@@ -24,11 +24,12 @@ export const useUserStore = create((set) => {
       }
     };
 
-  // Factory for axios GET calls where response has { data } shape
+  // Factory for axios GET calls — handles both plain arrays and { data, total } paginated responses
   const loadAxios = (getUrl, key) => async (id) => {
     set({ isLoading: true });
     try {
-      const { data } = await axios.get(getUrl(id));
+      const { data: payload } = await axios.get(getUrl(id));
+      const data = Array.isArray(payload) ? payload : payload.data;
       set({ [key]: data, isLoading: false });
     } catch (err) {
       setErr(set, err);

--- a/server/services/appointmentService.js
+++ b/server/services/appointmentService.js
@@ -37,12 +37,15 @@ const createAppointment = async (req) => {
 
 const getAppointments = async (req) => {
   const { limit, page } = getPaginationParams(req);
-  const appointments = await Appointment.find()
-    .populate("user", "username email phone")
-    .sort({ date: -1, createdAt: -1 })
-    .skip((page - 1) * limit)
-    .limit(limit);
-  return appointments;
+  const [appointments, total] = await Promise.all([
+    Appointment.find()
+      .populate("user", "username email phone")
+      .sort({ date: -1, createdAt: -1 })
+      .skip((page - 1) * limit)
+      .limit(limit),
+    Appointment.countDocuments(),
+  ]);
+  return { data: appointments, total, page, limit };
 };
 
 const getAppointment = async (req) => {
@@ -93,11 +96,14 @@ const getAppointmentsByStatus = async (req) => {
     throw createError(400, `Status must be one of: ${VALID_STATUSES.join(", ")}`);
   }
   const { limit, page } = getPaginationParams(req);
-  const appointments = await Appointment.find({ status })
-    .sort({ date: -1 })
-    .skip((page - 1) * limit)
-    .limit(limit);
-  return appointments;
+  const [appointments, total] = await Promise.all([
+    Appointment.find({ status })
+      .sort({ date: -1 })
+      .skip((page - 1) * limit)
+      .limit(limit),
+    Appointment.countDocuments({ status }),
+  ]);
+  return { data: appointments, total, page, limit };
 };
 
 const getAppointmentsByDateRange = async (req) => {
@@ -118,17 +124,16 @@ const getAppointmentsByDateRange = async (req) => {
     throw createError(400, "startDate must be before endDate");
   }
 
+  const dateFilter = { date: { $gte: start, $lte: end } };
   const { limit, page } = getPaginationParams(req);
-  const appointments = await Appointment.find({
-    date: {
-      $gte: start,
-      $lte: end,
-    },
-  })
-    .sort({ date: 1 })
-    .skip((page - 1) * limit)
-    .limit(limit);
-  return appointments;
+  const [appointments, total] = await Promise.all([
+    Appointment.find(dateFilter)
+      .sort({ date: 1 })
+      .skip((page - 1) * limit)
+      .limit(limit),
+    Appointment.countDocuments(dateFilter),
+  ]);
+  return { data: appointments, total, page, limit };
 };
 
 const appointmentService = {

--- a/server/services/carService.js
+++ b/server/services/carService.js
@@ -66,11 +66,14 @@ const getCar = async (req) => {
 
 const getCars = async (req) => {
   const { limit, page } = getPaginationParams(req);
-  const cars = await Car.find()
-    .populate("owner")
-    .skip((page - 1) * limit)
-    .limit(limit);
-  return cars;
+  const [cars, total] = await Promise.all([
+    Car.find()
+      .populate("owner")
+      .skip((page - 1) * limit)
+      .limit(limit),
+    Car.countDocuments(),
+  ]);
+  return { data: cars, total, page, limit };
 };
 
 const getCarsByType = async (req) =>

--- a/server/services/messageService.js
+++ b/server/services/messageService.js
@@ -78,23 +78,28 @@ const getMessage = async (req) => {
 };
 
 const getMessageByUser = async (req) => {
+  const filter = { $or: [{ to: req.params.id }, { from: req.params.id }] };
   const { limit, page } = getPaginationParams(req);
-  const messages = await Message.find({
-    $or: [{ to: req.params.id }, { from: req.params.id }],
-  })
-    .populate("to", "-password")
-    .populate("from", "-password")
-    .skip((page - 1) * limit)
-    .limit(limit);
-  return messages;
+  const [messages, total] = await Promise.all([
+    Message.find(filter)
+      .populate("to", "-password")
+      .populate("from", "-password")
+      .skip((page - 1) * limit)
+      .limit(limit),
+    Message.countDocuments(filter),
+  ]);
+  return { data: messages, total, page, limit };
 };
 
 const getMessages = async (req) => {
   const { limit, page } = getPaginationParams(req);
-  const messages = await Message.find()
-    .skip((page - 1) * limit)
-    .limit(limit);
-  return messages;
+  const [messages, total] = await Promise.all([
+    Message.find()
+      .skip((page - 1) * limit)
+      .limit(limit),
+    Message.countDocuments(),
+  ]);
+  return { data: messages, total, page, limit };
 };
 
 const getMessagesByType = async (req) =>

--- a/server/services/reviewService.js
+++ b/server/services/reviewService.js
@@ -19,11 +19,14 @@ const createReview = async (req) => {
 
 const getReviews = async (req) => {
   const { limit, page } = getPaginationParams(req);
-  const reviews = await Review.find()
-    .sort({ createdAt: -1 })
-    .skip((page - 1) * limit)
-    .limit(limit);
-  return reviews;
+  const [reviews, total] = await Promise.all([
+    Review.find()
+      .sort({ createdAt: -1 })
+      .skip((page - 1) * limit)
+      .limit(limit),
+    Review.countDocuments(),
+  ]);
+  return { data: reviews, total, page, limit };
 };
 
 const reviewService = {

--- a/server/services/serviceService.js
+++ b/server/services/serviceService.js
@@ -64,11 +64,14 @@ const getService = async (req) => {
 
 const getServices = async (req) => {
   const { limit, page } = getPaginationParams(req);
-  const services = await Service.find()
-    .populate("car")
-    .skip((page - 1) * limit)
-    .limit(limit);
-  return services;
+  const [services, total] = await Promise.all([
+    Service.find()
+      .populate("car")
+      .skip((page - 1) * limit)
+      .limit(limit),
+    Service.countDocuments(),
+  ]);
+  return { data: services, total, page, limit };
 };
 
 const getServicesByType = async (req) =>

--- a/server/services/userService.js
+++ b/server/services/userService.js
@@ -95,11 +95,14 @@ const getUser = async (req) => {
 
 const getUsers = async (req) => {
   const { limit, page } = getPaginationParams(req);
-  const users = await User.find()
-    .select("-password")
-    .skip((page - 1) * limit)
-    .limit(limit);
-  return users;
+  const [users, total] = await Promise.all([
+    User.find()
+      .select("-password")
+      .skip((page - 1) * limit)
+      .limit(limit),
+    User.countDocuments(),
+  ]);
+  return { data: users, total, page, limit };
 };
 
 const getUsersByType = async (req) =>


### PR DESCRIPTION
## What

All primary list services now return `{ data: [...], total, page, limit }` instead of bare arrays, matching the shape already used by the audit log endpoint. Client code is updated to extract the `data` array from the new payload so existing stores and UI remain unchanged.

**Server** (`services/` — 6 files):
- `getUsers`, `getAppointments`, `getAppointmentsByStatus`, `getAppointmentsByDateRange`, `getCars`, `getServices`, `getMessages`, `getMessageByUser`, `getReviews` — all now run a parallel `countDocuments()` and return `{ data, total, page, limit }`.

**Client** (3 files):
- `crudOperations.getAll` — extracts `payload.data` when the response is a paginated object, falls back to the raw array for endpoints not yet migrated.
- `appointmentsStore.fetchAppointments` — same `Array.isArray` guard for its direct axios call.
- `userStore.loadAxios` factory — same guard, needed because `getMessagesByIdUser` hits the now-paginated `/messages/user/:id` endpoint.

The `limit: 5000` request param is kept in `crudOperations.getAll` for now; removing it requires pagination UI controls, which is follow-up work.

## Why
Closes #309

## Test plan
- [ ] `GET /api/users?limit=2&page=1` returns `{ data: [...], total: N, page: 1, limit: 2 }` — not a bare array
- [ ] All admin tables (Users, Cars, Services, Messages) continue rendering correctly
- [ ] Appointments page loads without errors
- [ ] User account messages section loads correctly
- [ ] All 60 tests (33 server + 27 client) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)