### PR TITLE
fix: backend consistency and reliability — response shapes, cascades, shutdown, timestamps

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,4 +1,5 @@
 import dotenv from "dotenv";
+import mongoose from "mongoose";
 import connectDB from "./config/db.js";
 import app from "./app.js";
 
@@ -35,7 +36,8 @@ async function start() {
   });
 
   const shutdown = () => {
-    server.close(() => {
+    server.close(async () => {
+      await mongoose.connection.close();
       process.exit(0);
     });
   };

--- a/server/middleware/audit.js
+++ b/server/middleware/audit.js
@@ -17,7 +17,7 @@ export const auditAdmin = (action, targetModel) => (req, res, next) => {
         targetModel,
         targetId: req.params.id || req.params.userId || undefined,
         details: { method: req.method, path: req.originalUrl },
-      }).catch(() => {});
+      }).catch((err) => console.error("[audit] Failed to write log:", err.message));
     }
   });
   next();

--- a/server/models/Appointment.js
+++ b/server/models/Appointment.js
@@ -37,11 +37,7 @@ const AppointmentSchema = new Schema({
     enum: ["pending", "confirmed", "cancelled"],
     default: "pending",
   },
-  createdAt: {
-    type: Date,
-    default: Date.now,
-  },
-});
+}, { timestamps: true });
 
 AppointmentSchema.index({ date: 1 });
 AppointmentSchema.index({ status: 1 });

--- a/server/models/Appointment.js
+++ b/server/models/Appointment.js
@@ -1,43 +1,46 @@
 import mongoose from "mongoose";
 const { Schema, SchemaTypes } = mongoose;
 
-const AppointmentSchema = new Schema({
-  user: {
-    type: SchemaTypes.ObjectId,
-    ref: "User",
-    required: false,
+const AppointmentSchema = new Schema(
+  {
+    user: {
+      type: SchemaTypes.ObjectId,
+      ref: "User",
+      required: false,
+    },
+    clientName: {
+      type: String,
+      required: true,
+    },
+    email: {
+      type: String,
+      required: true,
+    },
+    phone: {
+      type: String,
+      required: true,
+    },
+    date: {
+      type: Date,
+      required: true,
+    },
+    time: {
+      type: String,
+      required: true,
+    },
+    notes: {
+      type: String,
+      required: false,
+      default: "",
+    },
+    status: {
+      type: String,
+      enum: ["pending", "confirmed", "cancelled"],
+      default: "pending",
+    },
   },
-  clientName: {
-    type: String,
-    required: true,
-  },
-  email: {
-    type: String,
-    required: true,
-  },
-  phone: {
-    type: String,
-    required: true,
-  },
-  date: {
-    type: Date,
-    required: true,
-  },
-  time: {
-    type: String,
-    required: true,
-  },
-  notes: {
-    type: String,
-    required: false,
-    default: "",
-  },
-  status: {
-    type: String,
-    enum: ["pending", "confirmed", "cancelled"],
-    default: "pending",
-  },
-}, { timestamps: true });
+  { timestamps: true }
+);
 
 AppointmentSchema.index({ date: 1 });
 AppointmentSchema.index({ status: 1 });

--- a/server/services/carService.js
+++ b/server/services/carService.js
@@ -84,7 +84,10 @@ const getCarsByType = async (req) =>
 const getCarsWithService = async (req) => {
   const { limit, page } = getPaginationParams(req);
   const [cars, total] = await Promise.all([
-    Car.find().populate("services").skip((page - 1) * limit).limit(limit),
+    Car.find()
+      .populate("services")
+      .skip((page - 1) * limit)
+      .limit(limit),
     Car.countDocuments(),
   ]);
   return { data: cars, total, page, limit };
@@ -94,7 +97,10 @@ const getCarsByOwner = async (req) => {
   const filter = { owner: req.params.user };
   const { limit, page } = getPaginationParams(req);
   const [cars, total] = await Promise.all([
-    Car.find(filter).populate("services").skip((page - 1) * limit).limit(limit),
+    Car.find(filter)
+      .populate("services")
+      .skip((page - 1) * limit)
+      .limit(limit),
     Car.countDocuments(filter),
   ]);
   return { data: cars, total, page, limit };

--- a/server/services/carService.js
+++ b/server/services/carService.js
@@ -1,5 +1,6 @@
 import Car from "../models/Car.js";
 import User from "../models/User.js";
+import Service from "../models/Service.js";
 import { templateCar } from "../utils/templates.js";
 import { createError } from "../utils/error.js";
 import {
@@ -55,6 +56,7 @@ const deleteCar = async (req) => {
   await Promise.all([
     Car.findByIdAndDelete(id),
     User.findByIdAndUpdate(userId, { $pull: { cars: id } }),
+    Service.deleteMany({ car: id }),
   ]);
   return "The Car has been removed";
 };
@@ -81,20 +83,21 @@ const getCarsByType = async (req) =>
 
 const getCarsWithService = async (req) => {
   const { limit, page } = getPaginationParams(req);
-  const cars = await Car.find()
-    .populate("services")
-    .skip((page - 1) * limit)
-    .limit(limit);
-  return cars;
+  const [cars, total] = await Promise.all([
+    Car.find().populate("services").skip((page - 1) * limit).limit(limit),
+    Car.countDocuments(),
+  ]);
+  return { data: cars, total, page, limit };
 };
 
 const getCarsByOwner = async (req) => {
+  const filter = { owner: req.params.user };
   const { limit, page } = getPaginationParams(req);
-  const cars = await Car.find({ owner: req.params.user })
-    .populate("services")
-    .skip((page - 1) * limit)
-    .limit(limit);
-  return cars;
+  const [cars, total] = await Promise.all([
+    Car.find(filter).populate("services").skip((page - 1) * limit).limit(limit),
+    Car.countDocuments(filter),
+  ]);
+  return { data: cars, total, page, limit };
 };
 
 const carService = {

--- a/server/services/reviewService.js
+++ b/server/services/reviewService.js
@@ -1,13 +1,14 @@
 import Review from "../models/Review.js";
 import User from "../models/User.js";
 import { getPaginationParams, pickAllowed } from "../utils/queryHelpers.js";
+import { createError } from "../utils/error.js";
 
 const ALLOWED_REVIEW_FIELDS = ["description", "stars"];
 
 const createReview = async (req) => {
   const safeBody = pickAllowed(req.body, ALLOWED_REVIEW_FIELDS);
   const author = await User.findById(req.user.id).select("username").lean();
-  if (!author) throw { status: 404, message: "User not found" };
+  if (!author) throw createError(404, "User not found");
   const newReview = new Review({
     ...safeBody,
     user: req.user.id,

--- a/server/services/serviceService.js
+++ b/server/services/serviceService.js
@@ -78,11 +78,13 @@ const getServicesByType = async (req) =>
   getPaginatedWithPopulate(Service, req, ALLOWED_SERVICE_POPULATE_FIELDS);
 
 const getServicesByCar = async (req) => {
+  const filter = { car: req.params.car };
   const { limit, page } = getPaginationParams(req);
-  const services = await Service.find({ car: req.params.car })
-    .skip((page - 1) * limit)
-    .limit(limit);
-  return services;
+  const [services, total] = await Promise.all([
+    Service.find(filter).skip((page - 1) * limit).limit(limit),
+    Service.countDocuments(filter),
+  ]);
+  return { data: services, total, page, limit };
 };
 
 const getServicesByUser = async (req) => {
@@ -92,8 +94,13 @@ const getServicesByUser = async (req) => {
   // Service has no user field — resolve via the user's cars
   const cars = await Car.find({ owner: req.params.user }).select("_id").lean();
   const carIds = cars.map((c) => c._id);
-  const services = await Service.find({ car: { $in: carIds } });
-  return services;
+  const filter = { car: { $in: carIds } };
+  const { limit, page } = getPaginationParams(req);
+  const [services, total] = await Promise.all([
+    Service.find(filter).skip((page - 1) * limit).limit(limit),
+    Service.countDocuments(filter),
+  ]);
+  return { data: services, total, page, limit };
 };
 
 const serviceService = {

--- a/server/services/serviceService.js
+++ b/server/services/serviceService.js
@@ -81,7 +81,9 @@ const getServicesByCar = async (req) => {
   const filter = { car: req.params.car };
   const { limit, page } = getPaginationParams(req);
   const [services, total] = await Promise.all([
-    Service.find(filter).skip((page - 1) * limit).limit(limit),
+    Service.find(filter)
+      .skip((page - 1) * limit)
+      .limit(limit),
     Service.countDocuments(filter),
   ]);
   return { data: services, total, page, limit };
@@ -97,7 +99,9 @@ const getServicesByUser = async (req) => {
   const filter = { car: { $in: carIds } };
   const { limit, page } = getPaginationParams(req);
   const [services, total] = await Promise.all([
-    Service.find(filter).skip((page - 1) * limit).limit(limit),
+    Service.find(filter)
+      .skip((page - 1) * limit)
+      .limit(limit),
     Service.countDocuments(filter),
   ]);
   return { data: services, total, page, limit };

--- a/server/utils/queryHelpers.js
+++ b/server/utils/queryHelpers.js
@@ -1,7 +1,7 @@
 import { createError } from "./error.js";
 
 const DEFAULT_LIMIT = 50;
-const MAX_LIMIT = 5000;
+const MAX_LIMIT = 500;
 
 export const getPaginationParams = (req) => ({
   limit: Math.min(parseInt(req.query.limit) || DEFAULT_LIMIT, MAX_LIMIT),
@@ -32,5 +32,9 @@ export const getPaginatedWithPopulate = async (
   if (selectFields) q.select(selectFields);
   if (populateSelect) q.populate(type, populateSelect);
   else q.populate(type);
-  return q.skip((page - 1) * limit).limit(limit);
+  const [data, total] = await Promise.all([
+    q.skip((page - 1) * limit).limit(limit),
+    Model.countDocuments(baseQuery),
+  ]);
+  return { data, total, page, limit };
 };


### PR DESCRIPTION
## Summary

### Pass 3 — Response shape consistency & data integrity
- **`MAX_LIMIT` regression** (`queryHelpers`): Restored from 5000 → 500 to prevent OOM on large collections.
- **`getPaginatedWithPopulate`** (`queryHelpers`): Added parallel `countDocuments` and returns `{ data, total, page, limit }` — consistent with all other list endpoints (previously returned a plain array, causing different shapes based on whether `?populate=` was passed).
- **`carService.deleteCar` cascade** (`carService`): Added `Service.deleteMany({ car: id })` so deleting a car no longer orphans its service records. Mirrors the `deleteUser` cascade added in a previous PR.
- **`getCarsWithService` / `getCarsByOwner`** (`carService`): Both now return `{ data, total, page, limit }`.
- **`getServicesByCar` / `getServicesByUser`** (`serviceService`): Both now return `{ data, total, page, limit }`; `getServicesByUser` also gains proper pagination (was previously unbounded).
- **`reviewService`** (`reviewService`): Throw `createError(404, ...)` instead of a plain `{}` object so the global error handler logs it correctly with `err.name` / `err.status`.

### Pass 4 — Server reliability
- **Graceful shutdown** (`index.js`): Added `mongoose.connection.close()` in the shutdown callback before `process.exit(0)` — previously only HTTP connections were drained, leaving the Mongoose socket open.
- **`Appointment` timestamps** (`models/Appointment`): Replaced manual `createdAt` field (no `updatedAt`) with `{ timestamps: true }` — status changes and data edits now have an `updatedAt` audit trail. Existing `createdAt` values in MongoDB are unaffected.
- **Audit write failures** (`middleware/audit`): Replaced `.catch(() => {})` with `console.error("[audit] Failed to write log:", ...)` so DB errors during auditing are visible in ops logs.

## Files changed

| File | Change |
|------|--------|
| `server/utils/queryHelpers.js` | MAX_LIMIT → 500; `getPaginatedWithPopulate` returns `{ data, total, page, limit }` |
| `server/services/carService.js` | `deleteCar` cascade; `getCarsWithService`/`getCarsByOwner` return paginated shape |
| `server/services/reviewService.js` | Use `createError` instead of plain object |
| `server/services/serviceService.js` | `getServicesByCar`/`getServicesByUser` paginated shape |
| `server/index.js` | Import mongoose; close connection in shutdown |
| `server/middleware/audit.js` | Log catch errors |
| `server/models/Appointment.js` | `{ timestamps: true }` replaces manual `createdAt` |

## Test plan

- [ ] `GET /api/cars/populate?populate=owner` → response has `{ data, total, page, limit }` shape
- [ ] `GET /api/services/car/:id` → response has `{ data, total, page, limit }` shape
- [ ] Delete a car → its service documents are also removed from the DB
- [ ] `GET /api/appointments` after an update → document has `updatedAt` field
- [ ] Send SIGTERM to server process → MongoDB connection closes cleanly (no "MongoNotConnectedError" in logs)
- [ ] Force-fail an `AuditLog.create` → `[audit] Failed to write log:` appears in server stdout

🤖 Generated with [Claude Code](https://claude.com/claude-code)