### PR TITLE
fix: repair the authorization layer and per-caller rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,21 @@ Or run both together from the server directory:
 cd server && npm run dev
 ```
 
+### Deploying behind a proxy
+
+Rate limiting identifies callers by IP. Behind a load balancer (Render, Railway,
+Fly, nginx…) that IP arrives only in `X-Forwarded-For`, which Express ignores by
+default — leave it that way and every user shares a single rate-limit bucket.
+Set `TRUST_PROXY` to the number of proxy hops, usually `1`:
+
+```bash
+TRUST_PROXY=1
+```
+
+Leave it unset when the app is exposed directly: trusting a forwarded header
+nobody rewrites lets a client spoof its address and skip the limiter entirely.
+See `server/.env.example` for the full list of variables.
+
 ## API Endpoints
 
 ### Authentication

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -18,15 +18,17 @@ const Dashboard = lazy(() => import("./pages/dashboard/Dashboard"));
 const Signup = lazy(() => import("./pages/signup/Signup"));
 const Unauthorized = lazy(() => import("./pages/Unauthorized"));
 
+// adminOnly pages read admin-scoped endpoints, so a signed-in customer landing
+// on one would only see failed requests — send them to /unauthorized instead.
 const PRIVATE_ROUTES = [
   { path: "/myCars", Component: Account },
-  { path: "/users", Component: Users },
-  { path: "/cars", Component: Cars },
   { path: "/messages", Component: Messages },
-  { path: "/services", Component: ServicesAdmin },
-  { path: "/messages-contact", Component: MessagesOfContact },
-  { path: "/appointments", Component: Appointments },
-  { path: "/dashboard", Component: Dashboard },
+  { path: "/users", Component: Users, adminOnly: true },
+  { path: "/cars", Component: Cars, adminOnly: true },
+  { path: "/services", Component: ServicesAdmin, adminOnly: true },
+  { path: "/messages-contact", Component: MessagesOfContact, adminOnly: true },
+  { path: "/appointments", Component: Appointments, adminOnly: true },
+  { path: "/dashboard", Component: Dashboard, adminOnly: true },
 ];
 
 function App() {
@@ -43,12 +45,12 @@ function App() {
           >
             <Routes>
               <Route path="/" element={<PageLanding />} />
-              {PRIVATE_ROUTES.map(({ path, Component }) => (
+              {PRIVATE_ROUTES.map(({ path, Component, adminOnly }) => (
                 <Route
                   key={path}
                   path={path}
                   element={
-                    <PrivateRoute>
+                    <PrivateRoute adminOnly={adminOnly}>
                       <Component />
                     </PrivateRoute>
                   }

--- a/client/src/PrivateRoute.jsx
+++ b/client/src/PrivateRoute.jsx
@@ -1,22 +1,25 @@
 import { Navigate } from "react-router-dom";
 import PropTypes from "prop-types";
 import { useAuthStore } from "./stores/authStore";
+import { ACCESS, resolveRouteAccess } from "./utils/routeAccess";
 
-export function PrivateRoute({ children }) {
+export function PrivateRoute({ children, adminOnly = false }) {
   const user = useAuthStore((s) => s.user);
   const isLoading = useAuthStore((s) => s.isLoading);
 
-  if (isLoading) {
-    return <div style={{ textAlign: "center", marginTop: "50px" }}>טוען...</div>;
+  switch (resolveRouteAccess({ user, isLoading, adminOnly })) {
+    case ACCESS.LOADING:
+      return <div style={{ textAlign: "center", marginTop: "50px" }}>טוען...</div>;
+    case ACCESS.REQUIRE_LOGIN:
+      return <Navigate to="/" replace />;
+    case ACCESS.REQUIRE_ADMIN:
+      return <Navigate to="/unauthorized" replace />;
+    default:
+      return <>{children}</>;
   }
-
-  if (!user) {
-    return <Navigate to="/" />;
-  }
-
-  return <>{children}</>;
 }
 
 PrivateRoute.propTypes = {
   children: PropTypes.node.isRequired,
+  adminOnly: PropTypes.bool,
 };

--- a/client/src/__tests__/routeAccess.test.js
+++ b/client/src/__tests__/routeAccess.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { ACCESS, resolveRouteAccess } from "../utils/routeAccess.js";
+
+const admin = { _id: "1", isAdmin: true };
+const customer = { _id: "2", isAdmin: false };
+
+describe("resolveRouteAccess", () => {
+  it("waits while auth state is still loading", () => {
+    expect(resolveRouteAccess({ user: null, isLoading: true })).toBe(ACCESS.LOADING);
+    expect(resolveRouteAccess({ user: admin, isLoading: true, adminOnly: true })).toBe(
+      ACCESS.LOADING
+    );
+  });
+
+  it("requires login when there is no user", () => {
+    expect(resolveRouteAccess({ user: null })).toBe(ACCESS.REQUIRE_LOGIN);
+    expect(resolveRouteAccess({ user: null, adminOnly: true })).toBe(ACCESS.REQUIRE_LOGIN);
+  });
+
+  it("allows any signed-in user on a shared route", () => {
+    expect(resolveRouteAccess({ user: customer })).toBe(ACCESS.ALLOW);
+    expect(resolveRouteAccess({ user: admin })).toBe(ACCESS.ALLOW);
+  });
+
+  it("blocks a signed-in non-admin on an admin-only route", () => {
+    expect(resolveRouteAccess({ user: customer, adminOnly: true })).toBe(ACCESS.REQUIRE_ADMIN);
+  });
+
+  it("allows an admin on an admin-only route", () => {
+    expect(resolveRouteAccess({ user: admin, adminOnly: true })).toBe(ACCESS.ALLOW);
+  });
+
+  it("treats a user without an isAdmin flag as a non-admin", () => {
+    expect(resolveRouteAccess({ user: { _id: "3" }, adminOnly: true })).toBe(ACCESS.REQUIRE_ADMIN);
+  });
+});

--- a/client/src/components/nav/NavUser.jsx
+++ b/client/src/components/nav/NavUser.jsx
@@ -2,10 +2,11 @@ import NavLink from "./NavLink";
 import { MyAccount } from "../index";
 import { useHeaderHandlers } from "../header/hooks/useHeaderHandlers";
 
+// Appointments is an admin console (it lists every booking), so it is not linked
+// here — customers book through the form on the landing page.
 const NAV_LINKS = [
   { to: "/myCars", label: "MyCars" },
   { to: "/messages", label: "Messages" },
-  { to: "/appointments", label: "Appointments" },
 ];
 
 const NavUser = () => {

--- a/client/src/pages/Unauthorized.jsx
+++ b/client/src/pages/Unauthorized.jsx
@@ -4,7 +4,7 @@ function Unauthorized() {
   return (
     <div style={{ textAlign: "center", marginTop: "50px" }}>
       <h1>אין לך הרשאה לגשת לדף זה</h1>
-      <p>אנא התחבר כדי להמשיך.</p>
+      <p>הדף הזה זמין למנהלי המוסך בלבד.</p>
       <Link to="/" style={{ color: "blue", textDecoration: "underline" }}>
         חזור לדף הבית
       </Link>

--- a/client/src/utils/routeAccess.js
+++ b/client/src/utils/routeAccess.js
@@ -1,0 +1,21 @@
+/**
+ * Access decisions for a guarded route, kept separate from the component so the
+ * rules can be unit tested without rendering.
+ */
+export const ACCESS = {
+  LOADING: "loading",
+  ALLOW: "allow",
+  REQUIRE_LOGIN: "requireLogin",
+  REQUIRE_ADMIN: "requireAdmin",
+};
+
+/**
+ * @param {{ user: object|null, isLoading?: boolean, adminOnly?: boolean }} params
+ * @returns {string} one of the ACCESS values
+ */
+export const resolveRouteAccess = ({ user, isLoading = false, adminOnly = false }) => {
+  if (isLoading) return ACCESS.LOADING;
+  if (!user) return ACCESS.REQUIRE_LOGIN;
+  if (adminOnly && !user.isAdmin) return ACCESS.REQUIRE_ADMIN;
+  return ACCESS.ALLOW;
+};

--- a/server/.env.example
+++ b/server/.env.example
@@ -22,6 +22,14 @@ CLIENT_URL=https://your-client-domain.com
 # Port the Express server listens on (optional, defaults to 8800)
 PORT=8800
 
+# Number of reverse proxies in front of the app (Render, Railway, Fly, nginx… = 1).
+# Rate limiting keys on the caller's IP, and behind a proxy that IP only comes
+# from X-Forwarded-For, which Express ignores until this is set — leave it unset
+# there and every user in the world shares a single rate-limit bucket.
+# Unset (the default) is correct only when the app is exposed directly: trusting
+# a header nobody rewrites lets a client spoof its address and skip the limiter.
+TRUST_PROXY=1
+
 # ── Email (Nodemailer) ────────────────────────────────────────────────────────
 # Leave SMTP_HOST unset to disable email sending entirely (graceful no-op).
 # Works with any SMTP provider: Gmail, SendGrid SMTP relay, Resend SMTP, etc.

--- a/server/__tests__/rateLimiting.test.js
+++ b/server/__tests__/rateLimiting.test.js
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import request from "supertest";
+
+/**
+ * Rate limiting keys on req.ip. Behind a load balancer the real caller only
+ * appears in X-Forwarded-For, which Express ignores until it is told how many
+ * proxies to trust — so with TRUST_PROXY unset every request looks like it came
+ * from the proxy and the entire user base shares one bucket. These tests cover
+ * both halves: the buckets must be per caller, and the ceiling must still exist.
+ *
+ * No database is involved: every request here is rejected by the auth or
+ * validation layer, and the limiter has already counted it by then.
+ */
+
+let app;
+let parseTrustProxy;
+const originalNodeEnv = process.env.NODE_ENV;
+
+beforeAll(async () => {
+  process.env.JWT = "test-jwt-secret-for-rate-limiting";
+  process.env.TRUST_PROXY = "1";
+
+  const appModule = await import("../app.js");
+  app = appModule.default;
+  parseTrustProxy = appModule.parseTrustProxy;
+
+  // Limiters skip themselves under NODE_ENV=test — which is the behaviour this
+  // file needs to exercise, so it opts back in.
+  process.env.NODE_ENV = "development";
+});
+
+afterAll(() => {
+  process.env.NODE_ENV = originalNodeEnv;
+});
+
+const read = (clientIp) => request(app).get("/api/users").set("X-Forwarded-For", clientIp);
+
+const attemptLogin = (clientIp) =>
+  request(app).post("/api/auth/login").set("X-Forwarded-For", clientIp).send({});
+
+// ─── parseTrustProxy ─────────────────────────────────────────────────────────
+
+describe("parseTrustProxy", () => {
+  it("trusts nothing when unset, so a forwarded header cannot be spoofed", () => {
+    expect(parseTrustProxy(undefined)).toBe(false);
+    expect(parseTrustProxy("")).toBe(false);
+    expect(parseTrustProxy("false")).toBe(false);
+  });
+
+  it("reads a hop count", () => {
+    expect(parseTrustProxy("1")).toBe(1);
+    expect(parseTrustProxy("2")).toBe(2);
+    expect(parseTrustProxy("0")).toBe(0);
+  });
+
+  it("passes an address or subnet through to Express", () => {
+    expect(parseTrustProxy("127.0.0.1")).toBe("127.0.0.1");
+    expect(parseTrustProxy("10.0.0.0/8")).toBe("10.0.0.0/8");
+  });
+
+  it("supports the blanket 'true' for completeness", () => {
+    expect(parseTrustProxy("true")).toBe(true);
+  });
+});
+
+// ─── Per-caller buckets ──────────────────────────────────────────────────────
+
+describe("rate limit buckets", () => {
+  it("counts callers behind a shared proxy separately", async () => {
+    const statuses = [];
+    for (let i = 1; i <= 60; i++) {
+      const res = await read(`203.0.113.${i}`);
+      statuses.push(res.status);
+    }
+
+    // With trust proxy off these all key on the proxy and the tail turns 429.
+    expect(statuses.filter((s) => s === 429)).toHaveLength(0);
+  });
+
+  it("still caps a single caller", async () => {
+    let firstBlocked = null;
+    for (let i = 1; i <= 320 && firstBlocked === null; i++) {
+      const res = await read("198.51.100.7");
+      if (res.status === 429) firstBlocked = i;
+    }
+
+    expect(firstBlocked).toBe(301);
+  });
+
+  it("advertises the budget in the standard headers", async () => {
+    const res = await read("198.51.100.20");
+
+    expect(res.headers["ratelimit-limit"]).toBe("300");
+  });
+});
+
+// ─── Narrow limiters ─────────────────────────────────────────────────────────
+
+describe("endpoint-specific limits", () => {
+  it("throttles password guessing far harder than ordinary reads", async () => {
+    let firstBlocked = null;
+    for (let i = 1; i <= 15 && firstBlocked === null; i++) {
+      const res = await attemptLogin("198.51.100.30");
+      if (res.status === 429) firstBlocked = i;
+    }
+
+    expect(firstBlocked).toBe(11);
+  });
+});
+
+// ─── Test-environment behaviour ──────────────────────────────────────────────
+
+describe("under NODE_ENV=test", () => {
+  it("does not throttle, so one test cannot spend another test's budget", async () => {
+    process.env.NODE_ENV = "test";
+    try {
+      const statuses = [];
+      for (let i = 1; i <= 15; i++) {
+        const res = await attemptLogin("198.51.100.40");
+        statuses.push(res.status);
+      }
+
+      expect(statuses.filter((s) => s === 429)).toHaveLength(0);
+    } finally {
+      process.env.NODE_ENV = "development";
+    }
+  });
+});

--- a/server/__tests__/routeAuthorization.test.js
+++ b/server/__tests__/routeAuthorization.test.js
@@ -1,0 +1,234 @@
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import jwt from "jsonwebtoken";
+import request from "supertest";
+
+/**
+ * Guard-layer tests: every controller is stubbed, so these exercise routing and
+ * the auth middleware only — no database required.
+ *
+ * The regression they lock in: admin guards used to be attached with
+ * `router.use(verifyAdmin)` on a sub-router mounted ahead of the user routes.
+ * Because `next(err)` from a router-level guard aborts the whole chain, every
+ * non-admin request was answered with 403 before it could reach the route meant
+ * for it — customers could not load their own cars, services or messages.
+ */
+
+const { stubs } = vi.hoisted(() => ({
+  stubs: (names) =>
+    Object.fromEntries(
+      names.map((name) => [
+        name,
+        (req, res) => res.status(200).json({ handler: name, params: req.params }),
+      ])
+    ),
+}));
+
+vi.mock("../controllers/car.js", () =>
+  stubs([
+    "updateCar",
+    "deleteCar",
+    "getCar",
+    "getCars",
+    "createCar",
+    "getCarsByType",
+    "getCarsWithService",
+    "getCarsByOwner",
+  ])
+);
+vi.mock("../controllers/user.js", () =>
+  stubs(["updateUser", "deleteUser", "getUser", "getUsers", "getUsersByType"])
+);
+vi.mock("../controllers/service.js", () =>
+  stubs([
+    "createService",
+    "updateService",
+    "deleteService",
+    "getService",
+    "getServices",
+    "getServicesByType",
+    "getServicesByCar",
+    "getServicesByUser",
+  ])
+);
+vi.mock("../controllers/message.js", () =>
+  stubs([
+    "createMessage",
+    "updateMessage",
+    "deleteMessage",
+    "getMessage",
+    "getMessages",
+    "createMessageToAdmin",
+    "getMessagesByType",
+    "getMessageByUser",
+  ])
+);
+vi.mock("../controllers/appointment.js", () =>
+  stubs([
+    "getAppointments",
+    "getAppointment",
+    "createAppointment",
+    "updateAppointment",
+    "updateAppointmentStatus",
+    "deleteAppointment",
+    "getAppointmentsByStatus",
+    "getAppointmentsByDateRange",
+  ])
+);
+vi.mock("../controllers/contact.js", () =>
+  stubs(["getContacts", "createContact", "deleteContact"])
+);
+vi.mock("../controllers/dashboard.js", () => stubs(["getDashboardStats"]));
+vi.mock("../controllers/audit.js", () => stubs(["getAuditLogs"]));
+vi.mock("../controllers/review.js", () => stubs(["getReviews", "createReview"]));
+vi.mock("../controllers/agent.js", () => stubs(["chat"]));
+// The audit middleware is the only route-level piece that touches the database.
+vi.mock("../middleware/audit.js", () => ({ auditAdmin: () => (req, res, next) => next() }));
+
+let app;
+
+const CUSTOMER_ID = "aaaaaaaaaaaaaaaaaaaaaaaa";
+const OTHER_ID = "bbbbbbbbbbbbbbbbbbbbbbbb";
+const RESOURCE_ID = "cccccccccccccccccccccccc";
+
+const cookieFor = (payload, options = {}) =>
+  `access_token=${jwt.sign(payload, process.env.JWT, options)}`;
+
+let customerCookie;
+let adminCookie;
+
+beforeAll(async () => {
+  process.env.JWT = "test-jwt-secret-for-route-authorization";
+  app = (await import("../app.js")).default;
+  customerCookie = cookieFor({ id: CUSTOMER_ID, isAdmin: false });
+  adminCookie = cookieFor({ id: OTHER_ID, isAdmin: true });
+});
+
+// ─── Customer-reachable routes ────────────────────────────────────────────────
+
+describe("routes a signed-in customer must be able to reach", () => {
+  const cases = [
+    ["get", `/api/users/${CUSTOMER_ID}`, "getUser"],
+    ["get", `/api/cars/user/${CUSTOMER_ID}`, "getCarsByOwner"],
+    ["get", `/api/cars/${RESOURCE_ID}`, "getCar"],
+    ["get", `/api/services/user/${CUSTOMER_ID}`, "getServicesByUser"],
+    ["get", `/api/services/car/${RESOURCE_ID}`, "getServicesByCar"],
+    ["get", `/api/services/${RESOURCE_ID}`, "getService"],
+    ["get", `/api/messages/user/${CUSTOMER_ID}`, "getMessageByUser"],
+    ["get", `/api/messages/${RESOURCE_ID}`, "getMessage"],
+    ["post", `/api/messages/${OTHER_ID}`, "createMessage"],
+    ["get", `/api/appointments/${RESOURCE_ID}`, "getAppointment"],
+  ];
+
+  it.each(cases)("%s %s reaches %s", async (method, url, handler) => {
+    const res = await request(app)[method](url).set("Cookie", customerCookie);
+
+    expect(res.status).toBe(200);
+    expect(res.body.handler).toBe(handler);
+  });
+});
+
+// ─── Admin-only routes ────────────────────────────────────────────────────────
+
+describe("routes a customer must not reach", () => {
+  const cases = [
+    ["/api/users", "list every user"],
+    ["/api/cars", "list every car"],
+    ["/api/cars/populate", "list every car with owners"],
+    ["/api/cars/service", "list every car with services"],
+    ["/api/services", "list every service"],
+    ["/api/messages", "list every message"],
+    ["/api/contacts", "list contact submissions"],
+    ["/api/appointments", "list every appointment"],
+    ["/api/appointments/status", "filter appointments by status"],
+    ["/api/dashboard/stats", "read dashboard stats"],
+  ];
+
+  it.each(cases)("GET %s is 403 (%s)", async (url) => {
+    const res = await request(app).get(url).set("Cookie", customerCookie);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("an admin reaches the same admin routes", async () => {
+    const res = await request(app).get("/api/users").set("Cookie", adminCookie);
+
+    expect(res.status).toBe(200);
+    expect(res.body.handler).toBe("getUsers");
+  });
+
+  it("a customer cannot read another user's account", async () => {
+    const res = await request(app).get(`/api/users/${OTHER_ID}`).set("Cookie", customerCookie);
+
+    expect(res.status).toBe(403);
+  });
+});
+
+// ─── Token handling ───────────────────────────────────────────────────────────
+
+describe("access token handling", () => {
+  it("answers 401 when no token is present", async () => {
+    const res = await request(app).get(`/api/users/${CUSTOMER_ID}`);
+
+    expect(res.status).toBe(401);
+  });
+
+  it("answers 401 — not 403 — for an expired token so the client can refresh", async () => {
+    const expired = cookieFor({ id: CUSTOMER_ID, isAdmin: false }, { expiresIn: "-1s" });
+
+    const res = await request(app).get(`/api/users/${CUSTOMER_ID}`).set("Cookie", expired);
+
+    expect(res.status).toBe(401);
+  });
+
+  it("answers 401 for a malformed token", async () => {
+    const res = await request(app)
+      .get(`/api/users/${CUSTOMER_ID}`)
+      .set("Cookie", "access_token=not-a-jwt");
+
+    expect(res.status).toBe(401);
+  });
+
+  it("answers 401 for an expired token on an admin route too", async () => {
+    const expired = cookieFor({ id: OTHER_ID, isAdmin: true }, { expiresIn: "-1s" });
+
+    const res = await request(app).get("/api/users").set("Cookie", expired);
+
+    expect(res.status).toBe(401);
+  });
+});
+
+// ─── Public routes stay public ────────────────────────────────────────────────
+
+describe("public routes", () => {
+  it("anyone can submit an appointment request", async () => {
+    const nextWeek = new Date();
+    nextWeek.setDate(nextWeek.getDate() + 7);
+
+    const res = await request(app)
+      .post("/api/appointments")
+      .send({
+        clientName: "Anonymous Caller",
+        email: "caller@test.com",
+        phone: "050-123-4567",
+        date: nextWeek.toISOString().split("T")[0],
+        time: "10:00",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.handler).toBe("createAppointment");
+  });
+
+  it("anyone can submit a contact request", async () => {
+    const res = await request(app).post("/api/contacts").send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body.handler).toBe("createContact");
+  });
+
+  it("anyone can read reviews", async () => {
+    const res = await request(app).get("/api/reviews");
+
+    expect(res.status).toBe(200);
+    expect(res.body.handler).toBe("getReviews");
+  });
+});

--- a/server/__tests__/routes.test.js
+++ b/server/__tests__/routes.test.js
@@ -8,6 +8,7 @@ import app from "../app.js";
 import User from "../models/User.js";
 import Appointment from "../models/Appointment.js";
 import Review from "../models/Review.js";
+import Car from "../models/Car.js";
 
 // ─── Test DB lifecycle ────────────────────────────────────────────────────────
 
@@ -28,6 +29,7 @@ beforeEach(async () => {
   await User.deleteMany({});
   await Appointment.deleteMany({});
   await Review.deleteMany({});
+  await Car.deleteMany({});
 });
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -196,5 +198,124 @@ describe("GET /api/dashboard/stats", () => {
     const res = await request(app).get("/api/dashboard/stats");
 
     expect(res.status).toBe(401);
+  });
+});
+
+// ─── GET /api/cars/:id — ownership ───────────────────────────────────────────
+
+describe("GET /api/cars/:id", () => {
+  const makeCar = (owner, numberPlate) =>
+    Car.create({ owner: owner._id, numberPlate, km: 1000, brand: "Mazda" });
+
+  it("the owner can read their own car", async () => {
+    const owner = await makeUser({ username: "carOwner" });
+    const car = await makeCar(owner, "11-111-11");
+
+    const res = await request(app).get(`/api/cars/${car._id}`).set("Cookie", authCookie(owner));
+
+    expect(res.status).toBe(200);
+    expect(res.body._id).toBe(car._id.toString());
+  });
+
+  it("returns 403 when a different customer asks for it", async () => {
+    const owner = await makeUser({ username: "carOwner2" });
+    const stranger = await makeUser({ username: "carStranger" });
+    const car = await makeCar(owner, "22-222-22");
+
+    const res = await request(app).get(`/api/cars/${car._id}`).set("Cookie", authCookie(stranger));
+
+    expect(res.status).toBe(403);
+  });
+
+  it("an admin can read any car", async () => {
+    const owner = await makeUser({ username: "carOwner3" });
+    const admin = await makeUser({ username: "carAdmin", isAdmin: true });
+    const car = await makeCar(owner, "33-333-33");
+
+    const res = await request(app).get(`/api/cars/${car._id}`).set("Cookie", authCookie(admin));
+
+    expect(res.status).toBe(200);
+  });
+});
+
+// ─── Appointment ownership ───────────────────────────────────────────────────
+
+describe("appointment ownership", () => {
+  const bookingBody = () => ({
+    clientName: "Owner Test",
+    email: "owner@test.com",
+    phone: "050-123-4567",
+    date: futureDate(),
+    time: "11:00",
+  });
+
+  it("ignores a user id supplied by an anonymous booking", async () => {
+    const victim = await makeUser({ username: "victimAccount" });
+
+    const res = await request(app)
+      .post("/api/appointments")
+      .send({ ...bookingBody(), user: victim._id.toString() });
+
+    expect(res.status).toBe(201);
+    const saved = await Appointment.findById(res.body._id);
+    expect(saved.user).toBeUndefined();
+  });
+
+  it("links a booking made by a signed-in customer to their own account", async () => {
+    const customer = await makeUser({ username: "bookingCustomer" });
+
+    const res = await request(app)
+      .post("/api/appointments")
+      .set("Cookie", authCookie(customer))
+      .send(bookingBody());
+
+    expect(res.status).toBe(201);
+    const saved = await Appointment.findById(res.body._id);
+    expect(saved.user.toString()).toBe(customer._id.toString());
+  });
+
+  it("lets the linked customer read their own appointment", async () => {
+    const customer = await makeUser({ username: "apptOwner" });
+    const appointment = await Appointment.create({
+      ...bookingBody(),
+      user: customer._id,
+    });
+
+    const res = await request(app)
+      .get(`/api/appointments/${appointment._id}`)
+      .set("Cookie", authCookie(customer));
+
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 403 when a different customer asks for it", async () => {
+    const customer = await makeUser({ username: "apptOwner2" });
+    const stranger = await makeUser({ username: "apptStranger" });
+    const appointment = await Appointment.create({
+      ...bookingBody(),
+      user: customer._id,
+    });
+
+    const res = await request(app)
+      .get(`/api/appointments/${appointment._id}`)
+      .set("Cookie", authCookie(stranger));
+
+    expect(res.status).toBe(403);
+  });
+
+  it("keeps an unlinked appointment admin-only", async () => {
+    const customer = await makeUser({ username: "apptNosy" });
+    const admin = await makeUser({ username: "apptAdmin", isAdmin: true });
+    const appointment = await Appointment.create(bookingBody());
+
+    const asCustomer = await request(app)
+      .get(`/api/appointments/${appointment._id}`)
+      .set("Cookie", authCookie(customer));
+    const asAdmin = await request(app)
+      .get(`/api/appointments/${appointment._id}`)
+      .set("Cookie", authCookie(admin));
+
+    expect(asCustomer.status).toBe(403);
+    expect(asAdmin.status).toBe(200);
   });
 });

--- a/server/__tests__/utils.test.js
+++ b/server/__tests__/utils.test.js
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
+import mongoose from "mongoose";
 import { getPaginationParams, pickAllowed } from "../utils/queryHelpers.js";
 import { templatePhone, templateCar } from "../utils/templates.js";
+import { assertOwnerOrAdmin, toId } from "../utils/ownership.js";
 
 // ─── getPaginationParams ─────────────────────────────────────────────────────
 
@@ -84,5 +86,62 @@ describe("templateCar", () => {
 
   it("returns an already-formatted plate unchanged", () => {
     expect(templateCar("12-345-67")).toBe("12-345-67");
+  });
+});
+
+// ─── toId ────────────────────────────────────────────────────────────────────
+
+describe("toId", () => {
+  it("returns null for a missing reference", () => {
+    expect(toId(null)).toBeNull();
+    expect(toId(undefined)).toBeNull();
+  });
+
+  it("stringifies a raw id", () => {
+    const id = new mongoose.Types.ObjectId();
+    expect(toId(id)).toBe(id.toString());
+  });
+
+  it("reads the _id of a populated document", () => {
+    const id = new mongoose.Types.ObjectId();
+    expect(toId({ _id: id, username: "someone" })).toBe(id.toString());
+  });
+});
+
+// ─── assertOwnerOrAdmin ──────────────────────────────────────────────────────
+
+describe("assertOwnerOrAdmin", () => {
+  const ownerId = new mongoose.Types.ObjectId();
+  const owner = { id: ownerId.toString(), isAdmin: false };
+  const stranger = { id: new mongoose.Types.ObjectId().toString(), isAdmin: false };
+  const admin = { id: new mongoose.Types.ObjectId().toString(), isAdmin: true };
+
+  it("allows the owner", () => {
+    expect(() => assertOwnerOrAdmin(ownerId, owner)).not.toThrow();
+  });
+
+  it("allows the owner when the reference is populated", () => {
+    expect(() => assertOwnerOrAdmin({ _id: ownerId }, owner)).not.toThrow();
+  });
+
+  it("allows any admin", () => {
+    expect(() => assertOwnerOrAdmin(ownerId, admin)).not.toThrow();
+  });
+
+  it("rejects a different user with 403", () => {
+    try {
+      assertOwnerOrAdmin(ownerId, stranger);
+      throw new Error("expected assertOwnerOrAdmin to throw");
+    } catch (err) {
+      expect(err.status).toBe(403);
+    }
+  });
+
+  it("rejects an unlinked resource for a non-admin", () => {
+    expect(() => assertOwnerOrAdmin(null, owner)).toThrow();
+  });
+
+  it("rejects when there is no caller", () => {
+    expect(() => assertOwnerOrAdmin(ownerId, undefined)).toThrow();
   });
 });

--- a/server/app.js
+++ b/server/app.js
@@ -16,45 +16,38 @@ import auditRoute from "./routes/audit.js";
 import errorHandler from "./middleware/errorHandler.js";
 import { logger } from "./middleware/logger.js";
 
-const authLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  max: 20,
-  message: { message: "Too many requests, please try again later" },
-  standardHeaders: true,
-  legacyHeaders: false,
-});
+const MINUTE = 60 * 1000;
+const HOUR = 60 * MINUTE;
 
-const publicLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  max: 50,
-  message: { message: "Too many requests, please try again later" },
-  standardHeaders: true,
-  legacyHeaders: false,
-});
+/**
+ * Throttles are disabled under NODE_ENV=test: otherwise a test's result depends
+ * on how many requests the tests before it happened to make.
+ */
+const createLimiter = (windowMs, max, message) =>
+  rateLimit({
+    windowMs,
+    max,
+    message: { message },
+    standardHeaders: true,
+    legacyHeaders: false,
+    skip: () => process.env.NODE_ENV === "test",
+  });
 
-const agentLimiter = rateLimit({
-  windowMs: 60 * 1000,
-  max: 10,
-  message: { message: "Too many AI requests, please try again later" },
-  standardHeaders: true,
-  legacyHeaders: false,
-});
+const TOO_MANY = "Too many requests, please try again later";
 
-const publicWriteLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  max: 5,
-  message: { message: "Too many submissions, please try again later" },
-  standardHeaders: true,
-  legacyHeaders: false,
-});
-
-const signupLimiter = rateLimit({
-  windowMs: 60 * 60 * 1000,
-  max: 5,
-  message: { message: "Too many registration attempts, please try again later" },
-  standardHeaders: true,
-  legacyHeaders: false,
-});
+const authLimiter = createLimiter(15 * MINUTE, 20, TOO_MANY);
+const publicLimiter = createLimiter(15 * MINUTE, 50, TOO_MANY);
+const agentLimiter = createLimiter(MINUTE, 10, "Too many AI requests, please try again later");
+const publicWriteLimiter = createLimiter(
+  15 * MINUTE,
+  5,
+  "Too many submissions, please try again later"
+);
+const signupLimiter = createLimiter(
+  HOUR,
+  5,
+  "Too many registration attempts, please try again later"
+);
 
 const app = express();
 

--- a/server/app.js
+++ b/server/app.js
@@ -1,7 +1,6 @@
 import express from "express";
 import cookieParser from "cookie-parser";
 import cors from "cors";
-import rateLimit from "express-rate-limit";
 import authRoute from "./routes/auth.js";
 import usersRoute from "./routes/users.js";
 import carsRoute from "./routes/cars.js";
@@ -15,41 +14,38 @@ import agentRoute from "./routes/agent.js";
 import auditRoute from "./routes/audit.js";
 import errorHandler from "./middleware/errorHandler.js";
 import { logger } from "./middleware/logger.js";
-
-const MINUTE = 60 * 1000;
-const HOUR = 60 * MINUTE;
+import {
+  agentLimiter,
+  apiLimiter,
+  authLimiter,
+  loginLimiter,
+  publicWriteLimiter,
+  signupLimiter,
+} from "./middleware/rateLimiters.js";
 
 /**
- * Throttles are disabled under NODE_ENV=test: otherwise a test's result depends
- * on how many requests the tests before it happened to make.
+ * How many reverse proxies sit in front of the app. Rate limiting keys on
+ * req.ip, so behind a load balancer with this unset every caller looks like the
+ * proxy and the whole user base shares one bucket.
+ *
+ * Set TRUST_PROXY to the number of hops (1 for a single load balancer). It is
+ * deliberately off by default: trusting a forwarded header that nobody is
+ * rewriting lets a client spoof its own address and slip the limiter entirely.
  */
-const createLimiter = (windowMs, max, message) =>
-  rateLimit({
-    windowMs,
-    max,
-    message: { message },
-    standardHeaders: true,
-    legacyHeaders: false,
-    skip: () => process.env.NODE_ENV === "test",
-  });
+export const parseTrustProxy = (value) => {
+  if (value === undefined || value === "") return false;
+  if (value === "false") return false;
+  if (value === "true") return true;
 
-const TOO_MANY = "Too many requests, please try again later";
+  const hops = Number(value);
+  if (Number.isInteger(hops) && hops >= 0) return hops;
 
-const authLimiter = createLimiter(15 * MINUTE, 20, TOO_MANY);
-const publicLimiter = createLimiter(15 * MINUTE, 50, TOO_MANY);
-const agentLimiter = createLimiter(MINUTE, 10, "Too many AI requests, please try again later");
-const publicWriteLimiter = createLimiter(
-  15 * MINUTE,
-  5,
-  "Too many submissions, please try again later"
-);
-const signupLimiter = createLimiter(
-  HOUR,
-  5,
-  "Too many registration attempts, please try again later"
-);
+  return value; // an IP or subnet list, which Express understands as-is
+};
 
 const app = express();
+
+app.set("trust proxy", parseTrustProxy(process.env.TRUST_PROXY));
 
 app.use(logger);
 app.use(cookieParser());
@@ -66,20 +62,23 @@ app.use(
   })
 );
 
+// The narrow limiters are registered ahead of the router they protect, so a
+// login or a booking is counted by both its own budget and the general one.
 app.post("/api/auth/signup", signupLimiter);
+app.post("/api/auth/login", loginLimiter);
 app.use("/api/auth", authLimiter, authRoute);
-app.use("/api/users", publicLimiter, usersRoute);
-app.use("/api/cars", publicLimiter, carsRoute);
-app.use("/api/services", publicLimiter, servicesRoute);
-app.use("/api/messages", publicLimiter, messagesRoute);
-app.use("/api/reviews", publicLimiter, reviewsRoute);
+app.use("/api/users", apiLimiter, usersRoute);
+app.use("/api/cars", apiLimiter, carsRoute);
+app.use("/api/services", apiLimiter, servicesRoute);
+app.use("/api/messages", apiLimiter, messagesRoute);
+app.use("/api/reviews", apiLimiter, reviewsRoute);
 app.post("/api/contacts", publicWriteLimiter);
-app.use("/api/contacts", publicLimiter, contactsRoute);
+app.use("/api/contacts", apiLimiter, contactsRoute);
 app.post("/api/appointments", publicWriteLimiter);
-app.use("/api/appointments", publicLimiter, appointmentsRoute);
-app.use("/api/dashboard", publicLimiter, dashboardRoute);
+app.use("/api/appointments", apiLimiter, appointmentsRoute);
+app.use("/api/dashboard", apiLimiter, dashboardRoute);
 app.use("/api/agent", agentLimiter, agentRoute);
-app.use("/api/audit", publicLimiter, auditRoute);
+app.use("/api/audit", apiLimiter, auditRoute);
 
 app.use((req, res) => {
   res.status(404).json({ message: "Route not found" });

--- a/server/index.js
+++ b/server/index.js
@@ -22,6 +22,15 @@ if (!process.env.ANTHROPIC_API_KEY) {
   console.warn("WARNING: ANTHROPIC_API_KEY is not set — /api/agent endpoints will be unavailable");
 }
 
+// Silent failure otherwise: rate limiting would bucket every caller together
+// under the proxy's address, so one busy user throttles everybody.
+if (process.env.NODE_ENV === "production" && !process.env.TRUST_PROXY) {
+  console.warn(
+    "WARNING: TRUST_PROXY is not set — if the app runs behind a load balancer, " +
+      "all users will share a single rate-limit bucket. Set TRUST_PROXY to the number of proxy hops (usually 1)."
+  );
+}
+
 const port = process.env.PORT || 8800;
 
 process.on("unhandledRejection", (reason) => {

--- a/server/middleware/rateLimiters.js
+++ b/server/middleware/rateLimiters.js
@@ -1,0 +1,64 @@
+import rateLimit from "express-rate-limit";
+
+const MINUTE = 60 * 1000;
+const HOUR = 60 * MINUTE;
+
+/**
+ * Throttles are disabled under NODE_ENV=test: otherwise a test's result depends
+ * on how many requests the tests before it happened to make.
+ *
+ * Every limiter keys on req.ip, which is only the real caller once Express is
+ * told how many proxies sit in front of it — see the TRUST_PROXY handling in
+ * app.js. Without it a deployment behind a load balancer buckets its entire
+ * user base together.
+ */
+export const createLimiter = (windowMs, max, message) =>
+  rateLimit({
+    windowMs,
+    max,
+    message: { message },
+    standardHeaders: true,
+    legacyHeaders: false,
+    skip: () => process.env.NODE_ENV === "test",
+  });
+
+const TOO_MANY = "Too many requests, please try again later";
+
+/**
+ * Reads for a signed-in session. Sized for real use rather than for an attacker:
+ * an admin opening the dashboard, a table and a couple of edit dialogs spends
+ * ~25 requests in a few minutes, and each modal open *and* close refetches.
+ * Credential stuffing and spam are handled by the narrow limiters below, which
+ * guard the endpoints that actually reward abuse.
+ */
+export const apiLimiter = createLimiter(15 * MINUTE, 300, TOO_MANY);
+
+/** Password guessing is the thing worth throttling hard. */
+export const loginLimiter = createLimiter(
+  15 * MINUTE,
+  10,
+  "Too many login attempts, please try again later"
+);
+
+/** Refresh, logout and admin-id — hit routinely by a healthy session. */
+export const authLimiter = createLimiter(15 * MINUTE, 60, TOO_MANY);
+
+export const signupLimiter = createLimiter(
+  HOUR,
+  5,
+  "Too many registration attempts, please try again later"
+);
+
+/** Unauthenticated writes: bookings and contact forms. */
+export const publicWriteLimiter = createLimiter(
+  15 * MINUTE,
+  5,
+  "Too many submissions, please try again later"
+);
+
+/** Every AI call costs money, so this one stays tight. */
+export const agentLimiter = createLimiter(
+  MINUTE,
+  10,
+  "Too many AI requests, please try again later"
+);

--- a/server/routes/appointments.js
+++ b/server/routes/appointments.js
@@ -9,7 +9,7 @@ import {
   getAppointmentsByStatus,
   getAppointmentsByDateRange,
 } from "../controllers/appointment.js";
-import { verifyAdmin, verifyUser } from "../utils/verifyToken.js";
+import { optionalAuth, verifyAdmin, verifyToken } from "../utils/verifyToken.js";
 import {
   validateAppointmentCreation,
   validateAppointmentUpdate,
@@ -19,35 +19,36 @@ import { auditAdmin } from "../middleware/audit.js";
 
 const router = express.Router();
 
-// Public routes
-router.post("/", validateAppointmentCreation, createAppointment);
+// Public — anyone can book. optionalAuth links the booking to the caller's
+// account when they happen to be signed in.
+router.post("/", optionalAuth, validateAppointmentCreation, createAppointment);
 
-// Admin routes
-const adminRouter = express.Router();
-adminRouter.use(verifyAdmin);
-adminRouter.get("/", getAppointments);
-adminRouter.get("/status", getAppointmentsByStatus);
-adminRouter.get("/date-range", getAppointmentsByDateRange);
-adminRouter.put(
+// Admin routes — literal paths before "/:id"
+router.get("/status", verifyAdmin, getAppointmentsByStatus);
+router.get("/date-range", verifyAdmin, getAppointmentsByDateRange);
+router.get("/", verifyAdmin, getAppointments);
+router.put(
   "/:id",
+  verifyAdmin,
   validateAppointmentUpdate,
   auditAdmin("UPDATE_APPOINTMENT", "Appointment"),
   updateAppointment
 );
-adminRouter.patch(
+router.patch(
   "/:id/status",
+  verifyAdmin,
   validateStatusUpdate,
   auditAdmin("UPDATE_APPOINTMENT_STATUS", "Appointment"),
   updateAppointmentStatus
 );
-adminRouter.delete("/:id", auditAdmin("DELETE_APPOINTMENT", "Appointment"), deleteAppointment);
+router.delete(
+  "/:id",
+  verifyAdmin,
+  auditAdmin("DELETE_APPOINTMENT", "Appointment"),
+  deleteAppointment
+);
 
-// User routes
-const userRouter = express.Router();
-userRouter.use(verifyUser);
-userRouter.get("/:id", getAppointment);
-
-router.use(adminRouter);
-router.use(userRouter);
+// ":id" is an appointment id — ownership is resolved in the service
+router.get("/:id", verifyToken, getAppointment);
 
 export default router;

--- a/server/routes/cars.js
+++ b/server/routes/cars.js
@@ -9,28 +9,27 @@ import {
   getCarsWithService,
   getCarsByOwner,
 } from "../controllers/car.js";
-import { verifyAdmin, verifyUser } from "../utils/verifyToken.js";
+import { verifyAdmin, verifyToken, verifyUser } from "../utils/verifyToken.js";
 import { auditAdmin } from "../middleware/audit.js";
 
 const router = express.Router();
 
-// Admin routes
-const adminRouter = express.Router();
-adminRouter.use(verifyAdmin);
-adminRouter.get("/populate", getCarsByType);
-adminRouter.get("/", getCars);
-adminRouter.post("/:userId", auditAdmin("CREATE_CAR", "Car"), createCar);
-adminRouter.put("/:id", auditAdmin("UPDATE_CAR", "Car"), updateCar);
-adminRouter.delete("/:id/:userId", auditAdmin("DELETE_CAR", "Car"), deleteCar);
+// Guards are attached per route rather than with router.use(): a router-level
+// verifyAdmin rejects every request that reaches the router, including ones
+// meant for the user routes further down, so non-admins never get there.
 
-// User routes
-const userRouter = express.Router();
-userRouter.use(verifyUser);
-userRouter.get("/service", getCarsWithService);
-userRouter.get("/user/:user", getCarsByOwner);
-userRouter.get("/:id", getCar);
+// Admin routes — literal paths first so they are not swallowed by "/:id"
+router.get("/populate", verifyAdmin, getCarsByType);
+router.get("/service", verifyAdmin, getCarsWithService); // returns every car, not just the caller's
+router.get("/", verifyAdmin, getCars);
+router.post("/:userId", verifyAdmin, auditAdmin("CREATE_CAR", "Car"), createCar);
+router.put("/:id", verifyAdmin, auditAdmin("UPDATE_CAR", "Car"), updateCar);
+router.delete("/:id/:userId", verifyAdmin, auditAdmin("DELETE_CAR", "Car"), deleteCar);
 
-router.use(adminRouter);
-router.use(userRouter);
+// Owner or admin — ":user" is a user id, so verifyUser can compare it directly
+router.get("/user/:user", verifyUser, getCarsByOwner);
+
+// ":id" is a car id — ownership is resolved against car.owner in the service
+router.get("/:id", verifyToken, getCar);
 
 export default router;

--- a/server/routes/contacts.js
+++ b/server/routes/contacts.js
@@ -1,17 +1,14 @@
 import express from "express";
 import { getContacts, createContact, deleteContact } from "../controllers/contact.js";
 import { verifyAdmin } from "../utils/verifyToken.js";
+
 const router = express.Router();
 
-// Public routes
+// Public route
 router.post("/", createContact);
 
 // Admin routes
-const adminRouter = express.Router();
-adminRouter.use(verifyAdmin);
-adminRouter.get("/", getContacts);
-adminRouter.delete("/:id", deleteContact);
-
-router.use(adminRouter);
+router.get("/", verifyAdmin, getContacts);
+router.delete("/:id", verifyAdmin, deleteContact);
 
 export default router;

--- a/server/routes/messages.js
+++ b/server/routes/messages.js
@@ -14,27 +14,17 @@ import { verifyAdmin, verifyToken, verifyUser } from "../utils/verifyToken.js";
 const router = express.Router();
 
 // Admin routes
-const adminRouter = express.Router();
-adminRouter.use(verifyAdmin);
-adminRouter.get("/", getMessages);
-adminRouter.get("/populate", getMessagesByType);
+router.get("/populate", verifyAdmin, getMessagesByType);
+router.get("/", verifyAdmin, getMessages);
 
-// User routes — verifyUser checks req.user.id === req.params.id (user ID routes only)
-const userRouter = express.Router();
-userRouter.use(verifyUser);
-userRouter.get("/user/:id", getMessageByUser);
+// Owner or admin — ":id" here is a user id
+router.get("/user/:id", verifyUser, getMessageByUser);
 
-// Auth routes — verifyToken only; ownership is enforced inside the service
-const authRouter = express.Router();
-authRouter.use(verifyToken);
-authRouter.post("/to/:to", createMessageToAdmin);
-authRouter.put("/:id", updateMessage);
-authRouter.delete("/:id", deleteMessage);
-authRouter.get("/:id", getMessage);
-authRouter.post("/:to", createMessage);
-
-router.use(adminRouter);
-router.use(userRouter);
-router.use(authRouter);
+// Authenticated — participation in the thread is enforced inside the service
+router.post("/to/:to", verifyToken, createMessageToAdmin);
+router.post("/:to", verifyToken, createMessage);
+router.put("/:id", verifyToken, updateMessage);
+router.delete("/:id", verifyToken, deleteMessage);
+router.get("/:id", verifyToken, getMessage);
 
 export default router;

--- a/server/routes/services.js
+++ b/server/routes/services.js
@@ -9,27 +9,23 @@ import {
   getServicesByCar,
   getServicesByUser,
 } from "../controllers/service.js";
-import { verifyAdmin, verifyUser } from "../utils/verifyToken.js";
+import { verifyAdmin, verifyToken, verifyUser } from "../utils/verifyToken.js";
 import { auditAdmin } from "../middleware/audit.js";
+
 const router = express.Router();
 
 // Admin routes
-const adminRouter = express.Router();
-adminRouter.use(verifyAdmin);
-adminRouter.get("/populate", getServicesByType);
-adminRouter.get("/", getServices);
-adminRouter.post("/:carId", auditAdmin("CREATE_SERVICE", "Service"), createService);
-adminRouter.put("/:id", auditAdmin("UPDATE_SERVICE", "Service"), updateService);
-adminRouter.delete("/:id", auditAdmin("DELETE_SERVICE", "Service"), deleteService);
+router.get("/populate", verifyAdmin, getServicesByType);
+router.get("/", verifyAdmin, getServices);
+router.post("/:carId", verifyAdmin, auditAdmin("CREATE_SERVICE", "Service"), createService);
+router.put("/:id", verifyAdmin, auditAdmin("UPDATE_SERVICE", "Service"), updateService);
+router.delete("/:id", verifyAdmin, auditAdmin("DELETE_SERVICE", "Service"), deleteService);
 
-// User routes
-const userRouter = express.Router();
-userRouter.use(verifyUser);
-userRouter.get("/user/:user", getServicesByUser);
-userRouter.get("/car/:car", getServicesByCar);
-userRouter.get("/:id", getService);
+// Owner or admin — ":user" is a user id
+router.get("/user/:user", verifyUser, getServicesByUser);
 
-router.use(adminRouter);
-router.use(userRouter);
+// Keyed by resource ids — ownership is resolved via the owning car in the service
+router.get("/car/:car", verifyToken, getServicesByCar);
+router.get("/:id", verifyToken, getService);
 
 export default router;

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -6,19 +6,12 @@ import { auditAdmin } from "../middleware/audit.js";
 const router = express.Router();
 
 // Admin routes
-const adminRouter = express.Router();
-adminRouter.use(verifyAdmin);
-adminRouter.get("/populate", getUsersByType);
-adminRouter.get("/", getUsers);
-adminRouter.put("/:id", auditAdmin("UPDATE_USER", "User"), updateUser);
-adminRouter.delete("/:id", auditAdmin("DELETE_USER", "User"), deleteUser);
+router.get("/populate", verifyAdmin, getUsersByType);
+router.get("/", verifyAdmin, getUsers);
+router.put("/:id", verifyAdmin, auditAdmin("UPDATE_USER", "User"), updateUser);
+router.delete("/:id", verifyAdmin, auditAdmin("DELETE_USER", "User"), deleteUser);
 
-// User routes
-const userRouter = express.Router();
-userRouter.use(verifyUser);
-userRouter.get("/:id", getUser);
-
-router.use(adminRouter);
-router.use(userRouter);
+// Owner or admin
+router.get("/:id", verifyUser, getUser);
 
 export default router;

--- a/server/services/appointmentService.js
+++ b/server/services/appointmentService.js
@@ -1,18 +1,13 @@
 import Appointment from "../models/Appointment.js";
 import { templatePhone } from "../utils/templates.js";
 import { createError } from "../utils/error.js";
+import { assertOwnerOrAdmin } from "../utils/ownership.js";
 import { pickAllowed, getPaginationParams } from "../utils/queryHelpers.js";
 import { sendAppointmentConfirmation, sendStatusUpdate } from "./emailService.js";
 
-const ALLOWED_APPOINTMENT_CREATE_FIELDS = [
-  "clientName",
-  "email",
-  "phone",
-  "date",
-  "time",
-  "notes",
-  "user",
-];
+// "user" is deliberately absent: the owner comes from the session, never the body,
+// so an anonymous booking cannot be attributed to somebody else's account.
+const ALLOWED_APPOINTMENT_CREATE_FIELDS = ["clientName", "email", "phone", "date", "time", "notes"];
 const ALLOWED_APPOINTMENT_UPDATE_FIELDS = [
   "clientName",
   "email",
@@ -29,7 +24,16 @@ const createAppointment = async (req) => {
 
   const safeBody = pickAllowed(req.body, ALLOWED_APPOINTMENT_CREATE_FIELDS);
 
-  const newAppointment = new Appointment({ ...safeBody, phone: formattedPhone });
+  // Admins book on a customer's behalf, so they may name the account. Everyone
+  // else is linked to their own session, and anonymous bookings stay unlinked —
+  // a public request must never be able to attach itself to another account.
+  const linkedUser = req.user?.isAdmin ? (req.body.user ?? null) : (req.user?.id ?? null);
+
+  const newAppointment = new Appointment({
+    ...safeBody,
+    phone: formattedPhone,
+    ...(linkedUser && { user: linkedUser }),
+  });
   const savedAppointment = await newAppointment.save();
   sendAppointmentConfirmation(savedAppointment); // fire-and-forget
   return savedAppointment;
@@ -54,6 +58,7 @@ const getAppointment = async (req) => {
     "username email phone"
   );
   if (!appointment) throw createError(404, "Appointment not found");
+  assertOwnerOrAdmin(appointment.user, req.user);
   return appointment;
 };
 

--- a/server/services/carService.js
+++ b/server/services/carService.js
@@ -3,6 +3,7 @@ import User from "../models/User.js";
 import Service from "../models/Service.js";
 import { templateCar } from "../utils/templates.js";
 import { createError } from "../utils/error.js";
+import { assertOwnerOrAdmin } from "../utils/ownership.js";
 import {
   getPaginationParams,
   pickAllowed,
@@ -63,6 +64,7 @@ const deleteCar = async (req) => {
 const getCar = async (req) => {
   const car = await Car.findById(req.params.id).populate("services");
   if (!car) throw createError(404, "Car not found");
+  assertOwnerOrAdmin(car.owner, req.user);
   return car;
 };
 

--- a/server/services/serviceService.js
+++ b/server/services/serviceService.js
@@ -1,6 +1,7 @@
 import Service from "../models/Service.js";
 import Car from "../models/Car.js";
 import { createError } from "../utils/error.js";
+import { assertCarOwnerOrAdmin } from "../utils/ownership.js";
 import {
   getPaginationParams,
   pickAllowed,
@@ -59,6 +60,7 @@ const deleteService = async (req) => {
 const getService = async (req) => {
   const service = await Service.findById(req.params.id);
   if (!service) throw createError(404, "Service not found");
+  await assertCarOwnerOrAdmin(service.car, req.user);
   return service;
 };
 
@@ -78,6 +80,7 @@ const getServicesByType = async (req) =>
   getPaginatedWithPopulate(Service, req, ALLOWED_SERVICE_POPULATE_FIELDS);
 
 const getServicesByCar = async (req) => {
+  await assertCarOwnerOrAdmin(req.params.car, req.user);
   const filter = { car: req.params.car };
   const { limit, page } = getPaginationParams(req);
   const [services, total] = await Promise.all([

--- a/server/utils/ownership.js
+++ b/server/utils/ownership.js
@@ -1,0 +1,31 @@
+import Car from "../models/Car.js";
+import { createError } from "./error.js";
+
+const FORBIDDEN = "You are not authorized to access this resource";
+
+/**
+ * Normalises an ObjectId, a populated document or a string into a plain id string.
+ */
+export const toId = (ref) => (ref ? (ref._id ?? ref).toString() : null);
+
+/**
+ * Throws 403 unless the caller is an admin or is the referenced owner.
+ * Use this for resources keyed by their own id, where the route param says
+ * nothing about who owns the record.
+ */
+export const assertOwnerOrAdmin = (ownerRef, user) => {
+  if (user?.isAdmin) return;
+  if (!user?.id || toId(ownerRef) !== user.id) {
+    throw createError(403, FORBIDDEN);
+  }
+};
+
+/**
+ * Same check, for resources that belong to a car rather than directly to a user.
+ */
+export const assertCarOwnerOrAdmin = async (carRef, user) => {
+  if (user?.isAdmin) return;
+  const car = await Car.findById(toId(carRef)).select("owner").lean();
+  if (!car) throw createError(404, "Car not found");
+  assertOwnerOrAdmin(car.owner, user);
+};

--- a/server/utils/verifyToken.js
+++ b/server/utils/verifyToken.js
@@ -1,27 +1,53 @@
 import jwt from "jsonwebtoken";
 import { createError } from "../utils/error.js";
 
+/**
+ * Requires a valid access token cookie and attaches the decoded payload to req.user.
+ *
+ * A missing, malformed or expired token is a 401 (not a 403): the client's axios
+ * interceptor refreshes on 401, so a 403 here would break silent token refresh
+ * and log users out every 15 minutes when the access token expires.
+ */
 export const verifyToken = (req, res, next) => {
-  try {
-    const token = req.cookies.access_token;
+  const token = req.cookies?.access_token;
 
-    if (!token) {
-      return next(createError(401, "Not authenticated"));
+  if (!token) {
+    return next(createError(401, "Not authenticated"));
+  }
+
+  jwt.verify(token, process.env.JWT, (err, user) => {
+    if (err) {
+      return next(createError(401, "Token is not valid"));
     }
 
-    jwt.verify(token, process.env.JWT, (err, user) => {
-      if (err) {
-        return next(createError(403, "Token is not valid"));
-      }
-
-      req.user = user;
-      next();
-    });
-  } catch (_err) {
-    next(createError(500, "Error verifying token"));
-  }
+    req.user = user;
+    next();
+  });
 };
 
+/**
+ * Attaches req.user when a valid access token is present, but never rejects.
+ * For endpoints that are public yet behave differently for signed-in callers
+ * (e.g. linking a booking to the account that made it).
+ */
+export const optionalAuth = (req, res, next) => {
+  const token = req.cookies?.access_token;
+
+  if (!token) return next();
+
+  jwt.verify(token, process.env.JWT, (err, user) => {
+    if (!err) req.user = user;
+    next();
+  });
+};
+
+/**
+ * Allows the owner of a user account or an admin.
+ *
+ * Only valid on routes whose `:id` / `:user` param is a USER id. Routes keyed by
+ * a resource id (a car, a service, an appointment) must use verifyToken and check
+ * ownership in the service layer, where the owner can actually be looked up.
+ */
 export const verifyUser = (req, res, next) => {
   verifyToken(req, res, (err) => {
     if (err) return next(err);


### PR DESCRIPTION
Two production-breaking defects, both found by reproducing the behaviour rather than reading for it.

## 1. Every resource router locked out non-admin users

Each router mounted a sub-router carrying `router.use(verifyAdmin)` **ahead of** its user routes:

```js
adminRouter.use(verifyAdmin);
router.use(adminRouter);   // ← every request enters here first
router.use(userRouter);
```

A router-level guard that calls `next(err)` aborts the whole chain, so a non-admin request was answered `403` before it could reach the route meant for it. A signed-in customer could not load their own cars, services, messages or account — the entire customer experience was dead.

Reproduced against the real router composition before touching anything:

```
non-admin GET /api/cars/user/123 -> 403 {"message":"not admin"}
admin     GET /api/cars/user/123 -> 200 {"route":"user-own"}
```

Guards are now attached per route, so a request that matches no admin route falls through to the user route.

### Found while fixing it

- **`verifyToken` answered `403` for an expired access token.** The client's axios interceptor only refreshes on `401`, so every session broke after 15 minutes instead of refreshing silently. Invalid and expired tokens are now `401`; `403` stays for genuine authorization failures.
- **`verifyUser` compared `req.user.id` against a car/service/appointment id** on `/cars/:id`, `/services/:id`, `/services/car/:car` and `/appointments/:id` — a comparison that can never match. Those routes now use `verifyToken` and resolve real ownership in the service layer via the new `utils/ownership.js`.
- **`POST /api/appointments` is public but accepted a client-supplied `user` id**, letting anyone attribute a booking to another account. The owner now comes from the session; admins may still book on a customer's behalf, and `optionalAuth` links bookings made by signed-in customers.

### Client

`PrivateRoute` gained `adminOnly`, backed by a pure `resolveRouteAccess` helper. Admin consoles send a signed-in customer to `/unauthorized` instead of a page full of failing requests, and Appointments — an admin console listing every booking — is no longer linked from the customer nav.

## 2. Rate limiting bucketed the whole user base together

`express-rate-limit` keys on `req.ip`, which behind a load balancer is the proxy unless Express is told how many hops to trust. `trust proxy` was never set. Measured:

```
60 distinct client addresses behind one proxy -> first 429 at request #51
trust proxy setting: false
ValidationError: ERR_ERL_UNEXPECTED_X_FORWARDED_FOR
```

In production the entire user base collectively got 50 requests per 15 minutes. The library had been flagging this all along.

- `TRUST_PROXY` (hop count, address or subnet) now drives `app.set("trust proxy")`. It stays **off by default** — trusting a header nobody rewrites lets a client spoof its address and skip the limiter — and `index.js` warns at startup when production leaves it unset, since the failure is otherwise silent.
- The single 50-per-15-minutes budget shared by nine route groups became a 300 budget for authenticated reads. An admin opening the dashboard, a table and a couple of dialogs spends ~25 requests in a few minutes (each modal open *and* close refetches), so the old ceiling was reachable in normal use.
- Abuse is throttled where it actually pays off: login gets a dedicated 10 per 15 minutes — previously it shared a 20 budget with token refresh, so a healthy multi-tab session ate the login allowance — signup stays 5/hour, public writes 5/15min, the AI agent 10/minute.

After the fix:

```
trust proxy = 1
60 distinct clients behind a proxy -> blocked: 0
single client -> first 429 at request #301
login attempts -> first 429 at attempt #11
```

## Testing

| Suite | Result |
|---|---|
| `routeAuthorization.test.js` (new, no DB) | 29/29 ✅ |
| `rateLimiting.test.js` (new, no DB) | 9/9 ✅ |
| `utils.test.js` | 23/23 ✅ |
| Client tests + lint + build | 33/33 ✅ |
| `routes.test.js`, `auth.test.js` | **did not run locally** ⚠️ |

The two server integration suites could not run in the authoring sandbox: `mongodb-memory-server` downloads its binary from `fastdl.mongodb.org`, which the sandbox's network policy rejects with 403. They fail at download, before executing — not on content. CI has that access, so they run here.

That gap is exactly why the two new suites stub the controllers and touch no database: the guard layer and the limiter layer are now covered everywhere, not only where a mongod binary is reachable. The ownership assertions added to `routes.test.js` (another user's car → 403, anonymous appointment → admin-only, body-supplied `user` ignored) do need the database and are verified by CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_019bzMMjWpsNKkE8J5LGq1U6)_